### PR TITLE
FIX: Allow Path or string to download routine

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -14,12 +14,12 @@ import imap_data_access
 logger = logging.getLogger(__name__)
 
 
-def download(file_path: str) -> Path:
+def download(file_path: Path | str) -> Path:
     """Download a file from the data archive.
 
     Parameters
     ----------
-    file_path : str
+    file_path : pathlib.Path or str
         Name of the file to download, optionally including the directory path
 
     Returns
@@ -28,7 +28,7 @@ def download(file_path: str) -> Path:
         Path to the downloaded file
     """
     destination = imap_data_access.config["DATA_DIR"]
-    if "/" not in file_path:
+    if isinstance(file_path, str) and "/" not in file_path:
         # Construct the directory structure from the filename
         # This is for science files that contain the directory structure in the filename
         # Otherwise, we assume the full path to the file was given

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -35,6 +35,8 @@ def _set_mock_data(mock_urlopen, data):
         ),
         # Directory structure provided in the request
         ("imap/test/config/file.txt", "imap/test/config/file.txt"),
+        # Pathlib.Path object
+        (Path("imap/test/config/file.txt"), "imap/test/config/file.txt"),
     ],
 )
 def test_download(mock_urlopen, file_path, destination):


### PR DESCRIPTION
# Change Summary

## Overview

Passing a pathlib object before caused errors on the `"/" in file_path` check due to it not being a string. We should only go down that path if we are passed strings, so add that case and add an explicit test for passing Path objects.