### PR TITLE
FIX: Update PyPI classifiers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/imap_processing
+      url: https://pypi.org/p/imap-data-access
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ license = {text = "MIT"}
 keywords = ["IMAP", "SDC", "SOC", "SDS", "Science Operations"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "Intended Audience :: SDS Users",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
The release failed with a bad classifier, so remove that classifier.
https://github.com/IMAP-Science-Operations-Center/imap-data-access/actions/runs/7718702465/job/21040708226