### PR TITLE
FIX: Allow relative paths and strings to be input to upload

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -156,15 +156,16 @@ def query(
     return items
 
 
-def upload(file_path: Path) -> None:
+def upload(file_path: Union[Path, str]) -> None:
     """Upload a file to the data archive.
 
     Parameters
     ----------
-    file_path : pathlib.Path
+    file_path : pathlib.Path or str
         Path to the file to upload. It must be located within
         the ``imap_data_access.config["DATA_DIR"]`` directory.
     """
+    file_path = Path(file_path).resolve()
     if not file_path.exists():
         raise FileNotFoundError(file_path)
 
@@ -179,7 +180,7 @@ def upload(file_path: Path) -> None:
 
     url = f"{imap_data_access.config['DATA_ACCESS_URL']}"
     # The upload name needs to be given as a path parameter
-    url += f"/upload/science/{upload_name}"
+    url += f"/upload/{upload_name}"
     logger.info("Uploading file %s to %s", file_path, url)
 
     # We send a GET request with the filename and the server

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -176,7 +176,10 @@ def upload(file_path: Union[Path, str]) -> None:
         )
 
     # Strip off the data directory to get the upload path + name
-    upload_name = str(file_path.relative_to(imap_data_access.config["DATA_DIR"]))
+    # Must be posix style for the URL
+    upload_name = str(
+        file_path.relative_to(imap_data_access.config["DATA_DIR"]).as_posix()
+    )
 
     url = f"{imap_data_access.config['DATA_ACCESS_URL']}"
     # The upload name needs to be given as a path parameter


### PR DESCRIPTION
This allows relative paths and strings to be uploaded. Before the routines required the absolute path even if you were in the data directory.
