### PR TITLE
FIX: Catch errors when using the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Download a level 0 SWE file on 2024/01/05
 
 ```bash
 $ imap-data-access download imap/swe/l0/2024/01/imap_swe_l0_sci_20240105_20240105_v00-00.pkts
-Downloaded the file to: <IMAP_DATA_DIR>/imap/swe/l0/2024/01/imap_swe_l0_sci_20240105_20240105_v00-00.pkts
+Successfully downloaded the file to: <IMAP_DATA_DIR>/imap/swe/l0/2024/01/imap_swe_l0_sci_20240105_20240105_v00-00.pkts
 ```
 
 ### Upload a file
@@ -41,7 +41,7 @@ Upload an l1a file after decoding the l0 CCSDS ".pkts" file
 
 ```bash
 $ imap-data-access upload imap/swe/l1a/2024/01/imap_swe_l1a_sci_20240105_20240105_v00-00.cdf
-Uploaded file to the SDC from: <IMAP_DATA_DIR>/imap/swe/l1a/2024/01/imap_swe_l1a_sci_20240105_20240105_v00-00.cdf
+Successfully uploaded the file to the IMAP SDC
 ```
 
 ## Importing as a package

--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -30,8 +30,11 @@ def _download_parser(args: argparse.Namespace):
     args : argparse.Namespace
         An object containing the parsed arguments and their values
     """
-    output_path = imap_data_access.download(args.file_path)
-    print(f"Downloaded the file to: {output_path}")
+    try:
+        output_path = imap_data_access.download(args.file_path)
+        print(f"Successfully downloaded the file to: {output_path}")
+    except imap_data_access.io.IMAPDataAccessError as e:
+        print(e)
 
 
 def _print_query_results_table(query_results):
@@ -101,7 +104,11 @@ def _query_parser(args: argparse.Namespace):
         for key, value in vars(args).items()
         if key in valid_args and value is not None
     }
-    query_results = imap_data_access.query(**query_params)
+    try:
+        query_results = imap_data_access.query(**query_params)
+    except imap_data_access.io.IMAPDataAccessError as e:
+        print(e)
+        return
 
     if args.output_format == "table":
         _print_query_results_table(query_results)
@@ -118,8 +125,11 @@ def _upload_parser(args: argparse.Namespace):
     args : argparse.Namespace
         An object containing the parsed arguments and their values
     """
-    imap_data_access.upload(args.file_path)
-    print(f"Uploaded file to the SDC from: {args.file_path}")
+    try:
+        imap_data_access.upload(args.file_path)
+        print("Successfully uploaded the file to the IMAP SDC")
+    except imap_data_access.io.IMAPDataAccessError as e:
+        print(e)
 
 
 def main():


### PR DESCRIPTION
This avoids the stack traces and only prints the messages of what hapened with the server errors instead.

Are these print statements what you'd expect to see as a user?
```bash
$ imap-data-access download a/b/c.txt
HTTP Error: 502 - Bad Gateway
Server Message: {"message": "Internal server error"}
```