### PR TITLE
Adding filename utility filename

### DIFF
--- a/imap_data_access/file_naming.py
+++ b/imap_data_access/file_naming.py
@@ -18,9 +18,9 @@ def extract_filename_components(filename: str):
     """
     pattern = (
         r"^imap_"
-        r"(?P<instrument>[^_]*)_"
-        r"(?P<datalevel>[^_]*)_"
-        r"(?P<descriptor>[^_]*)_"
+        r"(?P<instrument>[^_]+)_"
+        r"(?P<datalevel>[^_]+)_"
+        r"(?P<descriptor>[^_]*)_?"  # optional
         r"(?P<startdate>\d{8})_"
         r"(?P<enddate>\d{8})_"
         r"(?P<version>v\d{2}-\d{2})"

--- a/imap_data_access/file_naming.py
+++ b/imap_data_access/file_naming.py
@@ -1,0 +1,33 @@
+"""Methods for managing and validating filenames."""
+import re
+
+def extract_filename_components(filename: str):
+    """
+    Extracts all components from filename.
+
+    Parameters
+    ----------
+    filename : str
+        Path of dependency data.
+
+    Returns
+    -------
+    components : dict
+        Dictionary containing components.
+
+    """
+    pattern = (
+        r"^imap_"
+        r"(?P<instrument>[^_]*)_"
+        r"(?P<datalevel>[^_]*)_"
+        r"(?P<descriptor>[^_]*)_"
+        r"(?P<startdate>\d{8})_"
+        r"(?P<enddate>\d{8})_"
+        r"(?P<version>v\d{2}-\d{2})"
+        r"\.(cdf|pkts)$"
+    )
+    match = re.match(pattern, filename)
+    if match is None:
+        return
+    components = match.groupdict()
+    return components


### PR DESCRIPTION
# Change Summary
This is a proposal for this data-access repo - that we should move various filename related utilities out of SDS data manager/imap_processing and into this repo. Then it could be imported into both projects without duplicating code or needing to import large sds-data-manager into imap-processing. This could also be used to make additional command line utilities, such as `--validate filename`.

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
For now, just added a split method to break a file name into multiple components. In the future, I think moving [path_helper.py](https://github.com/IMAP-Science-Operations-Center/sds-data-manager/blob/dev/sds_data_manager/lambda_code/SDSCode/path_helper.py) into this project would make sense.

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- file_naming.py
   - The name of this file sucks, but I didn't want to name it `file_utils.py`
   - copied extract_filename method from [batch_starter.py](https://github.com/IMAP-Science-Operations-Center/sds-data-manager/blob/84e74b576b8f4e622d3d5619a62e9a294f8b1f71/sds_data_manager/lambda_code/SDSCode/batch_starter.py#L325)
