### PR TITLE
Adding universally useful file path and file name management to imap-data-access

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,26 @@ continue to encounter this, reach out to the IMAP SDC at
 This could mean that the local data directory is not set
 up with the same paths as the SDC. See the [data directory](#data-directory)
 section for an example of how to set this up.
+
+## File Validation
+
+This package validates filenames and paths to check they follow our standards, as defined by the filename conventions. There is also a class available for
+use by other packages to create filepaths and filenames that follow the IMAP SDC conventions.
+
+To use this class, use `imap_data_access.ScienceFilepath`.
+
+Usage:
+
+```python
+
+science_file = imap_data_access.ScienceFilePath("imap_swe_l0_sci_20240105_20240105_v00-05.pkts")
+
+# Filepath = /imap/swe/l0/2024/01/imap_swe_l0_sci_20240105_20240105_v00-05.pkts
+filepath = science_file.construct_file_path()
+
+# Use a data directory
+science_file = imap_data_access.ScienceFilePath("imap_swe_l0_sci_20240105_20240105_v00-05.pkts", data_dir="/data/personal")
+
+# Filepath = /data/personal/imap/swe/l0/2024/01/imap_swe_l0_sci_20240105_20240105_v00-05.pkts
+filepath = science_file.construct_file_path()
+```

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -8,8 +8,9 @@ import os
 from pathlib import Path
 
 from imap_data_access.io import download, query, upload
+from imap_data_access.file_validation import construct_upload_path
 
-__all__ = ["query", "download", "upload"]
+__all__ = ["query", "download", "upload", "construct_upload_path"]
 __version__ = "0.2.0"
 
 

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -7,10 +7,10 @@ provides a convenient way to query the IMAP data archive and download data files
 import os
 from pathlib import Path
 
-from imap_data_access.file_validation import ScienceFilepath
+from imap_data_access.file_validation import ScienceFilePath
 from imap_data_access.io import download, query, upload
 
-__all__ = ["query", "download", "upload", "ScienceFilepath"]
+__all__ = ["query", "download", "upload", "ScienceFilePath"]
 __version__ = "0.2.0"
 
 

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -7,10 +7,10 @@ provides a convenient way to query the IMAP data archive and download data files
 import os
 from pathlib import Path
 
-from imap_data_access.file_validation import construct_path_from_filename
+from imap_data_access.file_validation import ScienceFilepath
 from imap_data_access.io import download, query, upload
 
-__all__ = ["query", "download", "upload", "construct_path_from_filename"]
+__all__ = ["query", "download", "upload", "ScienceFilepath"]
 __version__ = "0.2.0"
 
 
@@ -44,7 +44,22 @@ VALID_INSTRUMENTS = {
     "ultra-90",
 }
 
-VALID_DATALEVELS = {"l0", "l1", "l1a", "l1b", "l1c", "l1d", "l2"}
+VALID_DATALEVELS = {
+    "l0",
+    "l1",
+    "l1a",
+    "l1b",
+    "l1c",
+    "l1ca",
+    "l1cb" "l1d",
+    "l2",
+    "l2pre",
+    "l3",
+    "l3a",
+    "l3b",
+    "l3c",
+    "l3d",
+}
 
 VALID_FILE_EXTENSION = {"pkts", "cdf"}
 

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -7,10 +7,10 @@ provides a convenient way to query the IMAP data archive and download data files
 import os
 from pathlib import Path
 
+from imap_data_access.file_validation import construct_path_from_filename
 from imap_data_access.io import download, query, upload
-from imap_data_access.file_validation import construct_upload_path
 
-__all__ = ["query", "download", "upload", "construct_upload_path"]
+__all__ = ["query", "download", "upload", "construct_path_from_filename"]
 __version__ = "0.2.0"
 
 
@@ -27,3 +27,28 @@ DATA_DIR : This is where the file data is stored and organized by instrument and
     "but this can be set on the command line using the --data-dir option, or through
     the environment variable IMAP_DATA_DIR.
 """
+
+
+VALID_INSTRUMENTS = {
+    "codice",
+    "glows",
+    "hit",
+    "hi-45",
+    "hi-90",
+    "idex",
+    "lo",
+    "mag",
+    "swapi",
+    "swe",
+    "ultra-45",
+    "ultra-90",
+}
+
+VALID_DATALEVELS = {"l0", "l1", "l1a", "l1b", "l1c", "l1d", "l2"}
+
+VALID_FILE_EXTENSION = {"pkts", "cdf"}
+
+FILENAME_CONVENTION = (
+    "<mission>_<instrument>_<datalevel>_<descriptor>_"
+    "<startdate>_<enddate>_<version>.<extension>"
+)

--- a/imap_data_access/file_naming.py
+++ b/imap_data_access/file_naming.py
@@ -18,9 +18,9 @@ def extract_filename_components(filename: str):
     """
     pattern = (
         r"^imap_"
-        r"(?P<instrument>[^_]*)_"
-        r"(?P<datalevel>[^_]*)_"
-        r"(?P<descriptor>[^_]*)_"
+        r"(?P<instrument>[^_]+)_"
+        r"(?P<datalevel>[^_]+)_"
+        r"(?P<descriptor>[^_]*)_?"  # optional
         r"(?P<startdate>\d{8})_"
         r"(?P<enddate>\d{8})_"
         r"(?P<version>v\d{2}-\d{2})"

--- a/imap_data_access/file_naming.py
+++ b/imap_data_access/file_naming.py
@@ -1,0 +1,33 @@
+"""Methods for managing and validating filenames."""
+import re
+
+def extract_filename_components(filename: str):
+    """
+    Extracts all components from filename.
+
+    Parameters
+    ----------
+    filename : str
+        Path of dependency data.
+
+    Returns
+    -------
+    components : dict
+        Dictionary containing components.
+
+    """
+    pattern = (
+        r"^imap_"
+        r"(?P<instrument>[^_]*)_"
+        r"(?P<datalevel>[^_]*)_"
+        r"(?P<descriptor>[^_]*)_"
+        r"(?P<startdate>\d{8})_"
+        r"(?P<enddate>\d{8})_"
+        r"(?P<version>v\d{2}-\d{2})"
+        r"\.(cdf|pkts)$"
+    )
+    match = re.match(pattern, filename)
+    if match is None:
+        return
+    components = match.groupdict()
+    return components

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -1,13 +1,22 @@
 """Methods for managing and validating filenames."""
 import re
+import pathlib
 
-def extract_filename_components(filename: str):
+def extract_filename_components(filename: type[str | pathlib.Path]):
     """
     Extracts all components from filename.
 
+    Will return a dictionary with the following keys:
+    { instrument, datalevel, descriptor, startdate, enddate, version, extension }
+
+    Descriptor is an optional field. If it is not present in the filename, the dict
+    value for "descriptor" will be "".
+
+    If a match is not found, a ValueError will be raised.
+
     Parameters
     ----------
-    filename : str
+    filename : Pathlib.Path or str
         Path of dependency data.
 
     Returns
@@ -26,8 +35,12 @@ def extract_filename_components(filename: str):
         r"(?P<version>v\d{2}-\d{2})"
         r"\.(cdf|pkts)$"
     )
+    if isinstance(filename, pathlib.Path):
+        filename = filename.name
+
     match = re.match(pattern, filename)
     if match is None:
-        return
+        raise ValueError(f"Filename {filename} does not match expected pattern")
+
     components = match.groupdict()
     return components

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import imap_data_access
 
 
-class ScienceFilepath:
+class ScienceFilePath:
     class InvalidScienceFileError(Exception):
         """Indicates a bad file type"""
 
@@ -24,7 +24,7 @@ class ScienceFilepath:
         <mission>_<instrument>_<datalevel>_<descriptor>_<startdate>_<enddate>
         _<version>.<extension>
 
-        NOTE: There are no optional parameters anymore. All parameters are required.
+        NOTE: There are no optional parameters. All parameters are required.
         <mission>: imap
         <instrument>: idex, swe, swapi, hi-45, ultra-45 and etc.
         <datalevel> : l1a, l1b, l1, l3a and etc.
@@ -217,7 +217,7 @@ class ScienceFilepath:
 
         match = re.match(pattern, filename)
         if match is None:
-            raise ScienceFilepath.InvalidScienceFileError(
+            raise ScienceFilePath.InvalidScienceFileError(
                 f"Filename {filename} does not match expected pattern: "
                 f"{imap_data_access.FILENAME_CONVENTION}"
             )

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -1,46 +1,214 @@
-"""Methods for managing and validating filenames."""
+"""Methods for managing and validating filenames and filepaths"""
 import re
 import pathlib
+from datetime import datetime
 
-def extract_filename_components(filename: type[str | pathlib.Path]):
-    """
-    Extracts all components from filename. Does not validate instrument or level.
+VALID_INSTRUMENTS = {
+    "codice",
+    "glows",
+    "hit",
+    "hi-45",
+    "hi-90",
+    "idex",
+    "lo",
+    "mag",
+    "swapi",
+    "swe",
+    "ultra-45",
+    "ultra-90",
+}
 
-    Will return a dictionary with the following keys:
-    { instrument, datalevel, descriptor, startdate, enddate, version, extension }
+VALID_DATALEVELS = {"l0", "l1", "l1a", "l1b", "l1c", "l1d", "l2"}
 
-    Descriptor is an optional field. If it is not present in the filename, the dict
-    value for "descriptor" will be "".
+VALID_FILE_EXTENSION = {"pkts", "cdf"}
 
-    If a match is not found, a ValueError will be raised.
+FILENAME_CONVENTION = (
+            "<mission>_<instrument>_<datalevel>_<descriptor>_"
+            "<startdate>_<enddate>_<version>.<extension>"
+        )
 
-    Parameters
-    ----------
-    filename : Pathlib.Path or str
-        Path of dependency data.
 
-    Returns
-    -------
-    components : dict
-        Dictionary containing components.
+class InvalidScienceFileError(Exception):
+    """Indicates a bad file type"""
+    pass
 
-    """
-    pattern = (
-        r"^imap_"
-        r"(?P<instrument>[^_]+)_"
-        r"(?P<datalevel>[^_]+)_"
-        r"(?P<descriptor>[^_]*)_?"  # optional
-        r"(?P<startdate>\d{8})_"
-        r"(?P<enddate>\d{8})_"
-        r"(?P<version>v\d{2}-\d{2})"
-        r"\.(cdf|pkts)$"
-    )
-    if isinstance(filename, pathlib.Path):
-        filename = filename.name
 
-    match = re.match(pattern, filename)
-    if match is None:
-        raise ValueError(f"Filename {filename} does not match expected pattern")
+class ScienceFilepathManager:
+    def __init__(self, filename: str | pathlib.Path):
+        """Class to store file pattern
 
-    components = match.groupdict()
-    return components
+        Current filename convention:
+        <mission>_<instrument>_<datalevel>_<descriptor>_<startdate>_<enddate>_<version>.<extension>
+
+        NOTE: There are no optional parameters anymore. All parameters are required.
+        <mission>: imap
+        <instrument>: idex, swe, swapi, hi-45, ultra-45 and etc.
+        <datalevel> : l1a, l1b, l1, l3a and etc.
+        <descriptor>: descriptor stores information specific to instrument. This is
+            decided by each instrument. For L0, "raw" is used.
+        <startdate>: startdate is the earliest date in the data. Format - YYYYMMDD
+        <enddate>: Some instrument and some data level requires to store date range.
+            If there is no end date, then startdate will be used as enddate as well.
+            Format - YYYYMMDD.
+        <version>: This stores software version and data version. Version format is
+            vxx-xx.
+
+        Parameters
+        ----------
+        filename : str | pathlib.Path
+            Science data filename or file path.
+        """
+        # TODO: Accomodate path or filename
+        self.filename = filename
+
+        try:
+            split_filename = ScienceFilepathManager.extract_filename_components(self.filename)
+        except ValueError:
+            raise InvalidScienceFileError(
+                f"Invalid filename. Expected file to match format: "
+                f"{FILENAME_CONVENTION}"
+            )
+
+        self.instrument = split_filename["instrument"]
+        self.data_level = split_filename["datalevel"]
+        self.descriptor = split_filename["descriptor"]
+        self.startdate = split_filename["startdate"]
+        self.enddate = split_filename["enddate"]
+        self.version = split_filename["version"]
+        self.extension = split_filename["extension"]
+
+        self.error_message = self.validate_filename()
+        if self.error_message:
+            raise InvalidScienceFileError(f"{self.error_message}")
+
+    def validate_filename(self):
+        """ Validate the filename and populate the error message for wrong attributes.
+
+        The error message will be an empty string if the filename is valid. Otherwise,
+        all errors with the filename will be put into the error message.
+
+        Returns
+        -------
+        error_message: str
+            Error message for specific missing attribute, or "" if the file name is
+            valid.
+        """
+        error_message = ""
+
+        if any(
+            attr is None or attr == ""
+            for attr in [
+                self.instrument,
+                self.data_level,
+                self.descriptor,
+                self.startdate,
+                self.enddate,
+                self.version,
+                self.extension,
+            ]
+        ):
+            error_message = f"Invalid filename, missing attribute. Filename " \
+                                 f"convention is {FILENAME_CONVENTION} \n"
+
+        if self.instrument not in VALID_INSTRUMENTS:
+            error_message += f"Invalid instrument {self.instrument}. Please choose " \
+                             f"from " f"{VALID_INSTRUMENTS} \n"
+        if self.data_level not in VALID_DATALEVELS:
+            error_message += f"Invalid data level {self.data_level}. Please choose " \
+                             f"from " f"{VALID_DATALEVELS} \n"
+        if not self.is_valid_date(self.startdate):
+            error_message += "Invalid start date format. Please use YYYYMMDD format. \n"
+        if not self.is_valid_date(self.enddate):
+            error_message += "Invalid end date format. Please use YYYYMMDD format. \n"
+        if not bool(re.match(r"^v\d{2}-\d{2}$", self.version)):
+            error_message += "Invalid version format. Please use vxx-xx format. \n"
+
+        if self.extension not in VALID_FILE_EXTENSION or (
+                (self.data_level == "l0" and self.extension != "pkts")
+                or (self.data_level != "l0" and self.extension != "cdf")
+        ):
+            error_message += "Invalid extension. Extension should be pkts for data " \
+                             "level l0 and cdf for data level higher than l0 \n"
+
+        return error_message
+
+    @staticmethod
+    def is_valid_date(input_date: str) -> bool:
+        """Check input date string is in valid format and is correct date
+
+        Parameters
+        ----------
+        input_date : str
+            Date in YYYYMMDD format.
+
+        Returns
+        -------
+        bool
+            Whether date input is valid or not
+        """
+
+        # Validate if it's a real date
+        try:
+            # This checks if date is in YYYYMMDD format.
+            # Sometimes, date is correct but not in the format we want
+            datetime.strptime(input_date, "%Y%m%d")
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
+    def extract_filename_components(filename: str | pathlib.Path):
+        """
+        Extracts all components from filename. Does not validate instrument or level.
+
+        Will return a dictionary with the following keys:
+        { instrument, datalevel, descriptor, startdate, enddate, version, extension }
+
+        If a match is not found, a ValueError will be raised.
+
+        Parameters
+        ----------
+        filename : Pathlib.Path or str
+            Path of dependency data.
+
+        Returns
+        -------
+        components : dict
+            Dictionary containing components.
+
+        """
+        pattern = (
+            r"^imap_"
+            r"(?P<instrument>[^_]+)_"
+            r"(?P<datalevel>[^_]+)_"
+            r"(?P<descriptor>[^_]+)_"
+            r"(?P<startdate>\d{8})_"
+            r"(?P<enddate>\d{8})_"
+            r"(?P<version>v\d{2}-\d{2})"
+            r"\.(cdf|pkts)$"
+        )
+        if isinstance(filename, pathlib.Path):
+            filename = filename.name
+
+        match = re.match(pattern, filename)
+        if match is None:
+            raise ValueError(f"Filename {filename} does not match expected pattern")
+
+        components = match.groupdict()
+        components["extension"] = match.group(7)
+        return components
+
+    def construct_upload_path(self):
+        """Construct upload path from class variables
+
+        Returns
+        -------
+        str
+            Upload path
+        """
+        upload_path = (
+            f"imap/{self.instrument}/{self.data_level}/"
+            f"{self.startdate[:4]}/{self.startdate[4:6]}/{self.filename}"
+        )
+
+        return upload_path

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -4,7 +4,7 @@ import pathlib
 
 def extract_filename_components(filename: type[str | pathlib.Path]):
     """
-    Extracts all components from filename.
+    Extracts all components from filename. Does not validate instrument or level.
 
     Will return a dictionary with the following keys:
     { instrument, datalevel, descriptor, startdate, enddate, version, extension }

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -72,7 +72,7 @@ def extract_filename_components(filename: str | Path):
     return components
 
 
-def construct_upload_path(filename: str | Path) -> str:
+def construct_upload_path(filename: str | Path) -> Path:
     """
     Given the filename, construct the expected upload path.
 
@@ -86,16 +86,20 @@ def construct_upload_path(filename: str | Path) -> str:
 
     Returns
     -------
-    str
+    Path
         File path generated from the filename.
 
     """
 
     components = extract_filename_components(filename)
+
     return (
-        f"{components['mission']}/{components['instrument']}/"
-        f"{components['datalevel']}/{components['startdate'][:4]}/"
-        f"{components['startdate'][4:6]}/{filename}"
+        Path(
+            f"{components['mission']}/{components['instrument']}/"
+            f"{components['datalevel']}/{components['startdate'][:4]}/"
+            f"{components['startdate'][4:6]}"
+        )
+        / filename
     )
 
 

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -65,9 +65,11 @@ def download(file_path: Union[Path, str]) -> Path:
         # This is for science files that contain the directory structure in the filename
         # Otherwise, we assume the full path to the file was given
 
-        construct = imap_data_access.construct_path_from_filename(file_path)
+        science_file_path = imap_data_access.ScienceFilepath(
+            file_path, data_dir=destination
+        )
 
-        destination = destination / construct
+        destination = science_file_path.construct_path()
     else:
         destination /= file_path
 

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -65,7 +65,7 @@ def download(file_path: Union[Path, str]) -> Path:
         # This is for science files that contain the directory structure in the filename
         # Otherwise, we assume the full path to the file was given
 
-        science_file_path = imap_data_access.ScienceFilepath(
+        science_file_path = imap_data_access.ScienceFilePath(
             file_path, data_dir=destination
         )
 

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -64,14 +64,12 @@ def download(file_path: Union[Path, str]) -> Path:
         # Construct the directory structure from the filename
         # This is for science files that contain the directory structure in the filename
         # Otherwise, we assume the full path to the file was given
-        parts = file_path.split("_")
-        instrument = parts[1]
-        datalevel = parts[2]
-        startdate = parts[4]
-        year = startdate[:4]
-        month = startdate[4:6]
-        destination = destination / instrument / datalevel / year / month
-    destination /= file_path
+
+        construct = imap_data_access.construct_upload_path(file_path)
+
+        destination = destination / construct
+    else:
+        destination /= file_path
 
     # Only download if the file doesn't already exist
     # TODO: Do we want to verify any hashes to make sure we have the right file?

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -65,7 +65,7 @@ def download(file_path: Union[Path, str]) -> Path:
         # This is for science files that contain the directory structure in the filename
         # Otherwise, we assume the full path to the file was given
 
-        construct = imap_data_access.construct_upload_path(file_path)
+        construct = imap_data_access.construct_path_from_filename(file_path)
 
         destination = destination / construct
     else:

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -1,40 +1,53 @@
 import pytest
 
-from imap_data_access.file_validation import ScienceFilepathManager, InvalidScienceFileError
+from imap_data_access.file_validation import (
+    ScienceFilepathManager,
+    InvalidScienceFileError,
+    extract_filename_components,
+)
 from pathlib import Path
 
 
 def test_extract_filename_components():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.pkts"
 
-    expected_output = {"instrument": "mag", "datalevel": "l1a", "descriptor": "burst", "startdate": "20210101", "enddate": "20210102", "version": "v01-01", "extension": "pkts"}
+    expected_output = {
+        "mission": "imap",
+        "instrument": "mag",
+        "datalevel": "l1a",
+        "descriptor": "burst",
+        "startdate": "20210101",
+        "enddate": "20210102",
+        "version": "v01-01",
+        "extension": "pkts",
+    }
 
-    assert ScienceFilepathManager.extract_filename_components(valid_filename) == expected_output
+    assert extract_filename_components(valid_filename) == expected_output
 
     # Descriptor is required
     invalid_filename = "imap_mag_l1a_20210101_20210102_v01-01.cdf"
 
     with pytest.raises(ValueError):
-        ScienceFilepathManager.extract_filename_components(invalid_filename)
+        extract_filename_components(invalid_filename)
 
     # start and end time are required
     invalid_filename = "imap_mag_l1a_20210101_v01-01"
     with pytest.raises(ValueError):
-        ScienceFilepathManager.extract_filename_components(invalid_filename)
+        extract_filename_components(invalid_filename)
 
     valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
     expected_output["extension"] = "cdf"
-    assert ScienceFilepathManager.extract_filename_components(valid_filepath) == \
-           expected_output
+    assert extract_filename_components(valid_filepath) == expected_output
 
     invalid_ext = "imap_mag_l1a_burst_20210101_20210102_v01-01.txt"
     with pytest.raises(ValueError):
-        ScienceFilepathManager.extract_filename_components(invalid_ext)
+        extract_filename_components(invalid_ext)
 
 
 def test_construct_sciencefilepathmanager():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
     sfm = ScienceFilepathManager(valid_filename)
+    assert sfm.mission == "imap"
     assert sfm.instrument == "mag"
     assert sfm.data_level == "l1a"
     assert sfm.descriptor == "burst"
@@ -84,7 +97,8 @@ def test_is_valid_date():
 def test_construct_upload_path():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
     sfm = ScienceFilepathManager(valid_filename)
-    expected_output = "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
+    expected_output = (
+        "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
+    )
 
-    assert sfm.construct_upload_path() == expected_output
-    
+    assert sfm.upload_path() == expected_output

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from imap_data_access.file_validation import ScienceFilepath
+from imap_data_access.file_validation import ScienceFilePath
 
 
 def test_extract_filename_components():
@@ -20,34 +20,34 @@ def test_extract_filename_components():
     }
 
     assert (
-        ScienceFilepath.extract_filename_components(valid_filename) == expected_output
+        ScienceFilePath.extract_filename_components(valid_filename) == expected_output
     )
 
     # Descriptor is required
     invalid_filename = "imap_mag_l1a_20210101_20210102_v01-01.cdf"
 
-    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
-        ScienceFilepath.extract_filename_components(invalid_filename)
+    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+        ScienceFilePath.extract_filename_components(invalid_filename)
 
     # start and end time are required
     invalid_filename = "imap_mag_l1a_20210101_v01-01"
-    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
-        ScienceFilepath.extract_filename_components(invalid_filename)
+    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+        ScienceFilePath.extract_filename_components(invalid_filename)
 
     valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
     expected_output["extension"] = "cdf"
     assert (
-        ScienceFilepath.extract_filename_components(valid_filepath) == expected_output
+        ScienceFilePath.extract_filename_components(valid_filepath) == expected_output
     )
 
     invalid_ext = "imap_mag_l1a_burst_20210101_20210102_v01-01.txt"
-    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
-        ScienceFilepath.extract_filename_components(invalid_ext)
+    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+        ScienceFilePath.extract_filename_components(invalid_ext)
 
 
 def test_construct_sciencefilepathmanager():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
-    sfm = ScienceFilepath(valid_filename)
+    sfm = ScienceFilePath(valid_filename)
     assert sfm.mission == "imap"
     assert sfm.instrument == "mag"
     assert sfm.data_level == "l1a"
@@ -58,19 +58,19 @@ def test_construct_sciencefilepathmanager():
     assert sfm.extension == "cdf"
 
     invalid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01"
-    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
-        ScienceFilepath(invalid_filename)
+    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+        ScienceFilePath(invalid_filename)
 
     invalid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.pkts"
-    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
-        ScienceFilepath(invalid_filename)
+    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+        ScienceFilePath(invalid_filename)
 
     invalid_filename = "imap_sdc_l1a_burst_20210101_20210102_v01-01.cdf"
-    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
-        ScienceFilepath(invalid_filename)
+    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+        ScienceFilePath(invalid_filename)
 
     valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
-    sfm = ScienceFilepath(valid_filepath)
+    sfm = ScienceFilePath(valid_filepath)
 
     assert sfm.instrument == "mag"
     assert sfm.data_level == "l1a"
@@ -83,21 +83,21 @@ def test_construct_sciencefilepathmanager():
 
 def test_is_valid_date():
     valid_date = "20210101"
-    assert ScienceFilepath.is_valid_date(valid_date)
+    assert ScienceFilePath.is_valid_date(valid_date)
 
     invalid_date = "2021-01-01"
-    assert not ScienceFilepath.is_valid_date(invalid_date)
+    assert not ScienceFilePath.is_valid_date(invalid_date)
 
     invalid_date = "20210132"
-    assert not ScienceFilepath.is_valid_date(invalid_date)
+    assert not ScienceFilePath.is_valid_date(invalid_date)
 
     invalid_date = "2021010"
-    assert not ScienceFilepath.is_valid_date(invalid_date)
+    assert not ScienceFilePath.is_valid_date(invalid_date)
 
 
 def test_construct_upload_path():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
-    sfm = ScienceFilepath(valid_filename)
+    sfm = ScienceFilePath(valid_filename)
     expected_output = Path(
         "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
     )
@@ -109,7 +109,7 @@ def test_data_dir():
     optional_data_dir = Path("/test/data")
     valid_filename = Path("imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
 
-    sfm = ScienceFilepath(valid_filename, data_dir=optional_data_dir)
+    sfm = ScienceFilePath(valid_filename, data_dir=optional_data_dir)
     expected_output = Path(
         "/test/data/imap/mag/l1a/2021/01/"
         "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -1,11 +1,8 @@
+from pathlib import Path
+
 import pytest
 
-from imap_data_access.file_validation import (
-    ScienceFilepathManager,
-    InvalidScienceFileError,
-    extract_filename_components,
-)
-from pathlib import Path
+from imap_data_access.file_validation import ScienceFilepath
 
 
 def test_extract_filename_components():
@@ -22,31 +19,35 @@ def test_extract_filename_components():
         "extension": "pkts",
     }
 
-    assert extract_filename_components(valid_filename) == expected_output
+    assert (
+        ScienceFilepath.extract_filename_components(valid_filename) == expected_output
+    )
 
     # Descriptor is required
     invalid_filename = "imap_mag_l1a_20210101_20210102_v01-01.cdf"
 
-    with pytest.raises(ValueError):
-        extract_filename_components(invalid_filename)
+    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
+        ScienceFilepath.extract_filename_components(invalid_filename)
 
     # start and end time are required
     invalid_filename = "imap_mag_l1a_20210101_v01-01"
-    with pytest.raises(ValueError):
-        extract_filename_components(invalid_filename)
+    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
+        ScienceFilepath.extract_filename_components(invalid_filename)
 
     valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
     expected_output["extension"] = "cdf"
-    assert extract_filename_components(valid_filepath) == expected_output
+    assert (
+        ScienceFilepath.extract_filename_components(valid_filepath) == expected_output
+    )
 
     invalid_ext = "imap_mag_l1a_burst_20210101_20210102_v01-01.txt"
-    with pytest.raises(ValueError):
-        extract_filename_components(invalid_ext)
+    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
+        ScienceFilepath.extract_filename_components(invalid_ext)
 
 
 def test_construct_sciencefilepathmanager():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
-    sfm = ScienceFilepathManager(valid_filename)
+    sfm = ScienceFilepath(valid_filename)
     assert sfm.mission == "imap"
     assert sfm.instrument == "mag"
     assert sfm.data_level == "l1a"
@@ -57,19 +58,19 @@ def test_construct_sciencefilepathmanager():
     assert sfm.extension == "cdf"
 
     invalid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01"
-    with pytest.raises(InvalidScienceFileError):
-        ScienceFilepathManager(invalid_filename)
+    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
+        ScienceFilepath(invalid_filename)
 
     invalid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.pkts"
-    with pytest.raises(InvalidScienceFileError):
-        ScienceFilepathManager(invalid_filename)
+    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
+        ScienceFilepath(invalid_filename)
 
     invalid_filename = "imap_sdc_l1a_burst_20210101_20210102_v01-01.cdf"
-    with pytest.raises(InvalidScienceFileError):
-        ScienceFilepathManager(invalid_filename)
+    with pytest.raises(ScienceFilepath.InvalidScienceFileError):
+        ScienceFilepath(invalid_filename)
 
     valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
-    sfm = ScienceFilepathManager(valid_filepath)
+    sfm = ScienceFilepath(valid_filepath)
 
     assert sfm.instrument == "mag"
     assert sfm.data_level == "l1a"
@@ -82,23 +83,36 @@ def test_construct_sciencefilepathmanager():
 
 def test_is_valid_date():
     valid_date = "20210101"
-    assert ScienceFilepathManager.is_valid_date(valid_date)
+    assert ScienceFilepath.is_valid_date(valid_date)
 
     invalid_date = "2021-01-01"
-    assert not ScienceFilepathManager.is_valid_date(invalid_date)
+    assert not ScienceFilepath.is_valid_date(invalid_date)
 
     invalid_date = "20210132"
-    assert not ScienceFilepathManager.is_valid_date(invalid_date)
+    assert not ScienceFilepath.is_valid_date(invalid_date)
 
     invalid_date = "2021010"
-    assert not ScienceFilepathManager.is_valid_date(invalid_date)
+    assert not ScienceFilepath.is_valid_date(invalid_date)
 
 
 def test_construct_upload_path():
     valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
-    sfm = ScienceFilepathManager(valid_filename)
-    expected_output = (
+    sfm = ScienceFilepath(valid_filename)
+    expected_output = Path(
         "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
     )
 
-    assert sfm.upload_path() == expected_output
+    assert sfm.construct_path() == expected_output
+
+
+def test_data_dir():
+    optional_data_dir = Path("/test/data")
+    valid_filename = Path("imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
+
+    sfm = ScienceFilepath(valid_filename, data_dir=optional_data_dir)
+    expected_output = Path(
+        "/test/data/imap/mag/l1a/2021/01/"
+        "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
+    )
+
+    assert sfm.construct_path() == expected_output

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -1,0 +1,90 @@
+import pytest
+
+from imap_data_access.file_validation import ScienceFilepathManager, InvalidScienceFileError
+from pathlib import Path
+
+
+def test_extract_filename_components():
+    valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.pkts"
+
+    expected_output = {"instrument": "mag", "datalevel": "l1a", "descriptor": "burst", "startdate": "20210101", "enddate": "20210102", "version": "v01-01", "extension": "pkts"}
+
+    assert ScienceFilepathManager.extract_filename_components(valid_filename) == expected_output
+
+    # Descriptor is required
+    invalid_filename = "imap_mag_l1a_20210101_20210102_v01-01.cdf"
+
+    with pytest.raises(ValueError):
+        ScienceFilepathManager.extract_filename_components(invalid_filename)
+
+    # start and end time are required
+    invalid_filename = "imap_mag_l1a_20210101_v01-01"
+    with pytest.raises(ValueError):
+        ScienceFilepathManager.extract_filename_components(invalid_filename)
+
+    valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
+    expected_output["extension"] = "cdf"
+    assert ScienceFilepathManager.extract_filename_components(valid_filepath) == \
+           expected_output
+
+    invalid_ext = "imap_mag_l1a_burst_20210101_20210102_v01-01.txt"
+    with pytest.raises(ValueError):
+        ScienceFilepathManager.extract_filename_components(invalid_ext)
+
+
+def test_construct_sciencefilepathmanager():
+    valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
+    sfm = ScienceFilepathManager(valid_filename)
+    assert sfm.instrument == "mag"
+    assert sfm.data_level == "l1a"
+    assert sfm.descriptor == "burst"
+    assert sfm.startdate == "20210101"
+    assert sfm.enddate == "20210102"
+    assert sfm.version == "v01-01"
+    assert sfm.extension == "cdf"
+
+    invalid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01"
+    with pytest.raises(InvalidScienceFileError):
+        ScienceFilepathManager(invalid_filename)
+
+    invalid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.pkts"
+    with pytest.raises(InvalidScienceFileError):
+        ScienceFilepathManager(invalid_filename)
+
+    invalid_filename = "imap_sdc_l1a_burst_20210101_20210102_v01-01.cdf"
+    with pytest.raises(InvalidScienceFileError):
+        ScienceFilepathManager(invalid_filename)
+
+    valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf")
+    sfm = ScienceFilepathManager(valid_filepath)
+
+    assert sfm.instrument == "mag"
+    assert sfm.data_level == "l1a"
+    assert sfm.descriptor == "burst"
+    assert sfm.startdate == "20210101"
+    assert sfm.enddate == "20210102"
+    assert sfm.version == "v01-01"
+    assert sfm.extension == "cdf"
+
+
+def test_is_valid_date():
+    valid_date = "20210101"
+    assert ScienceFilepathManager.is_valid_date(valid_date)
+
+    invalid_date = "2021-01-01"
+    assert not ScienceFilepathManager.is_valid_date(invalid_date)
+
+    invalid_date = "20210132"
+    assert not ScienceFilepathManager.is_valid_date(invalid_date)
+
+    invalid_date = "2021010"
+    assert not ScienceFilepathManager.is_valid_date(invalid_date)
+
+
+def test_construct_upload_path():
+    valid_filename = "imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
+    sfm = ScienceFilepathManager(valid_filename)
+    expected_output = "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_20210102_v01-01.cdf"
+
+    assert sfm.construct_upload_path() == expected_output
+    

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -48,7 +48,7 @@ def test_request_errors(mock_urlopen):
         # Directory structure inferred
         (
             "imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
-            "test/l1/2010/01/imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
+            "imap/test/l1/2010/01/imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
         ),
         # Directory structure provided in the request
         ("imap/test/config/file.txt", "imap/test/config/file.txt"),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -47,8 +47,8 @@ def test_request_errors(mock_urlopen):
     [
         # Directory structure inferred
         (
-            "imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
-            "imap/test/l1/2010/01/imap_test_l1_test-description_20100101_20100102_v00-00.cdf",
+            "imap_swe_l1_test-description_20100101_20100102_v00-00.cdf",
+            "imap/swe/l1/2010/01/imap_swe_l1_test-description_20100101_20100102_v00-00.cdf",
         ),
         # Directory structure provided in the request
         ("imap/test/config/file.txt", "imap/test/config/file.txt"),
@@ -104,8 +104,8 @@ def test_download_already_exists(mock_urlopen):
     [
         # All parameters should send full query
         {
-            "instrument": "test-instrument",
-            "data_level": "test-level",
+            "instrument": "swe",
+            "data_level": "l0",
             "descriptor": "test-description",
             "start_date": "20100101",
             "end_date": "20100102",
@@ -113,7 +113,7 @@ def test_download_already_exists(mock_urlopen):
             "extension": "pkts",
         },
         # Make sure not all query params are sent if they are missing
-        {"instrument": "test-instrument", "data_level": "test-level"},
+        {"instrument": "swe", "data_level": "l0"},
     ],
 )
 def test_query(mock_urlopen, query_params):


### PR DESCRIPTION
# Change Summary
Moving some of the file management stuff from sds-data-manager to this repo for wider use. I'd appreciate a close review from @bourque, @greglucas, and @tech3371 to make sure this lines up with what they are expecting

## Overview
Added new file_validation.py file, with a shared ScienceFilepathManager class (copied from Tenzin's work on sds-manager, I need to add her and Laura as coauthors actually), which I refactored slightly for more wide adoption. Also added some useful shared methods in that file and a list of valid instruments and levels. 

## New Dependencies
I moved the project to poetry (don't leave me unattended) to match the other projects. No new dependencies there though

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- imap_data_access/file_validation.py

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_data_access/io.py
   - updated to move some logic out of the function and use the new shared functionality. I would appreciate a closer look at these changes in case I messed up the way the expected path works.
   
## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Updated one test to add `imap/` as part of the expected path... I think this is correct, but would appreciate a double-check. 