### PR TITLE
Minor bugfix to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    needs: build_sdist
     environment:
       name: pypi
       url: https://pypi.org/p/imap-data-access


### PR DESCRIPTION
# Change Summary
I noticed the release workflow would run both jobs at the same time, when the pypi publish step has a dependency on the release step. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
Checked this on my fork: https://github.com/maxinelasp/imap-data-access/actions/runs/7892399492