### PR TITLE
FIX: Repointing should be an empty string when not present

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -72,7 +72,8 @@ def _print_query_results_table(query_results: list[dict]):
             item["data_level"],
             item["descriptor"],
             item["start_date"],
-            item["repointing"],
+            # Repointing is optional, so use an empty string if not present
+            item["repointing"] or "",
             item["version"],
             os.path.basename(item["file_path"]),
         ]


### PR DESCRIPTION
# Change Summary

The repointing is an optional parameter, so if it is None we should print an empty string in the format table.

closes #26

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- new file 1
   - description of new file 1's purpose

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
- deleted file 1
   - explanation for why file was deleted

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- updated file 1
   - description of change 1 in file 1
   - description of change 2 in file 2
- updated file 2
   - description of change 1 in file 2

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
