### PR TITLE
MNT: Exit with a parser error from the CLI

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -291,7 +291,10 @@ def main():
 
     # Now process through the respective function for the invoked command
     # (set with set_defaults on the subparsers above)
-    args.func(args)
+    try:
+        args.func(args)
+    except Exception as e:
+        parser.error(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If there is an error currently we print out a long stack trace. We can change this to just print the error message through a parser error rather than via the full stack trace when using this package as a CLI utility.

Testing with just query and no parameters provides this output now.
```bash
imap-data-access query
usage: imap-data-access [-h] [--version] [--data-dir DATA_DIR] [--url URL] [--debug]
                        [-v]
                        {download,query,upload} ...
imap-data-access: error: At least one query parameter must be provided
```

closes #30 