### PR TITLE
ENH: Allow SPICE file downloads/uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Documentation ignore
 docs/source/code-documentation/generated
 
+# Ignore the data directory in case that gets created
+data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -77,32 +77,3 @@ FILENAME_CONVENTION = (
     "<mission>_<instrument>_<datalevel>_<descriptor>_"
     "<startdate>(-<repointing>)_<version>.<extension>"
 )
-
-VALID_SPICE_EXTENSIONS = {
-    "bc",
-    "bds",
-    "bes",
-    "bpc",
-    "bsp",
-    "tf",
-    "ti",
-    "tls",
-    "tm",
-    "tpc",
-    "tsc",
-}
-"""These are the valid extensions for SPICE files according to NAIF
-https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
-
-.bc    binary CK
-.bds   binary DSK
-.bes   binary Sequence Component EK
-.bpc   binary PCK
-.bsp   binary SPK
-.tf    text FK
-.ti    text IK
-.tls   text LSK
-.tm    text meta-kernel (FURNSH kernel)
-.tpc   text PCK
-.tsc   text SCLK
-"""

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -8,7 +8,7 @@ provides a convenient way to query the IMAP data archive and download data files
 import os
 from pathlib import Path
 
-from imap_data_access.file_validation import ScienceFilePath
+from imap_data_access.file_validation import ScienceFilePath, SPICEFilePath
 from imap_data_access.io import download, query, upload
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "download",
     "upload",
     "ScienceFilePath",
+    "SPICEFilePath",
     "VALID_INSTRUMENTS",
     "VALID_DATALEVELS",
     "VALID_FILE_EXTENSION",
@@ -76,3 +77,32 @@ FILENAME_CONVENTION = (
     "<mission>_<instrument>_<datalevel>_<descriptor>_"
     "<startdate>(-<repointing>)_<version>.<extension>"
 )
+
+VALID_SPICE_EXTENSIONS = {
+    "bc",
+    "bds",
+    "bes",
+    "bpc",
+    "bsp",
+    "tf",
+    "ti",
+    "tls",
+    "tm",
+    "tpc",
+    "tsc",
+}
+"""These are the valid extensions for SPICE files according to NAIF
+https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
+
+.bc    binary CK
+.bds   binary DSK
+.bes   binary Sequence Component EK
+.bpc   binary PCK
+.bsp   binary SPK
+.tf    text FK
+.ti    text IK
+.tls   text LSK
+.tm    text meta-kernel (FURNSH kernel)
+.tpc   text PCK
+.tsc   text SCLK
+"""

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -278,6 +278,38 @@ class ScienceFilePath:
         return components
 
 
+# Transform the suffix to the directory structure we are using
+# Commented out mappings are not being used on IMAP
+_SPICE_DIR_MAPPING = {
+    ".bc": "ck",
+    # ".bds": "dsk",
+    # ".bes": "ek",
+    ".bpc": "pck",
+    ".bsp": "spk",
+    ".tf": "fk",
+    # "ti": "ik",
+    ".tls": "lsk",
+    ".tm": "mk",
+    ".tpc": "pck",
+    ".tsc": "sclk",
+}
+"""These are the valid extensions for SPICE files according to NAIF
+https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
+
+.bc    binary CK
+.bds   binary DSK
+.bes   binary Sequence Component EK
+.bpc   binary PCK
+.bsp   binary SPK
+.tf    text FK
+.ti    text IK
+.tls   text LSK
+.tm    text meta-kernel (FURNSH kernel)
+.tpc   text PCK
+.tsc   text SCLK
+"""
+
+
 class SPICEFilePath:
     """Class for building and validating filepaths for SPICE files."""
 
@@ -301,12 +333,11 @@ class SPICEFilePath:
             SPICE data filename or file path.
         """
         self.filename = Path(filename)
-        self.spice_dir = imap_data_access.config["DATA_DIR"] / "imap/spice"
 
-        if self.filename.suffix[1:] not in imap_data_access.VALID_SPICE_EXTENSIONS:
+        if self.filename.suffix not in _SPICE_DIR_MAPPING:
             raise self.InvalidSPICEFileError(
                 f"Invalid SPICE file. Expected file to have one of the following "
-                f"extensions {imap_data_access.VALID_SPICE_EXTENSIONS}"
+                f"extensions {list(_SPICE_DIR_MAPPING.keys())}"
             )
 
     def construct_path(self) -> Path:
@@ -320,17 +351,8 @@ class SPICEFilePath:
         Path
             Upload path
         """
-        # Transform the suffix to the proper directory structure we are expecting
-        suffix_mapping = {
-            ".bc": "ck",
-            ".tf": "fk",
-            ".tls": "lsk",
-            ".tm": "mk",
-            ".tpc": "pck",
-            ".tsc": "sclk",
-            ".bsp": "spk",
-        }
-        subdir = suffix_mapping[self.filename.suffix]
+        spice_dir = imap_data_access.config["DATA_DIR"] / "imap/spice"
+        subdir = _SPICE_DIR_MAPPING[self.filename.suffix]
         # Use the file suffix to determine the directory structure
-        # IMAP_DATA_DIR/spice/<subdir>/filename
-        return self.spice_dir / subdir / self.filename
+        # IMAP_DATA_DIR/imap/spice/<subdir>/filename
+        return spice_dir / subdir / self.filename

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -63,7 +63,7 @@ def download(file_path: Union[Path, str]) -> Path:
     destination = imap_data_access.config["DATA_DIR"]
     # Create the proper file path object based on the extension and filename
     file_path = Path(file_path)
-    if file_path.suffix[1:] in imap_data_access.VALID_SPICE_EXTENSIONS:
+    if file_path.suffix in imap_data_access.file_validation._SPICE_DIR_MAPPING:
         # SPICE
         path_obj = imap_data_access.SPICEFilePath(file_path.name)
     else:

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -61,16 +61,19 @@ def download(file_path: Union[Path, str]) -> Path:
         Path to the downloaded file
     """
     destination = imap_data_access.config["DATA_DIR"]
-    if isinstance(file_path, str) and "/" not in file_path:
-        # Construct the directory structure from the filename
-        # This is for science files that contain the directory structure in the filename
-        # Otherwise, we assume the full path to the file was given
-
-        science_file_path = imap_data_access.ScienceFilePath(file_path)
-
-        destination = science_file_path.construct_path()
+    # Create the proper file path object based on the extension and filename
+    file_path = Path(file_path)
+    if file_path.suffix[1:] in imap_data_access.VALID_SPICE_EXTENSIONS:
+        # SPICE
+        path_obj = imap_data_access.SPICEFilePath(file_path.name)
     else:
-        destination /= file_path
+        # Science
+        path_obj = imap_data_access.ScienceFilePath(file_path.name)
+
+    destination = path_obj.construct_path()
+
+    # Update the file_path with the full path for the download below
+    file_path = destination.relative_to(imap_data_access.config["DATA_DIR"]).as_posix()
 
     # Only download if the file doesn't already exist
     # TODO: Do we want to verify any hashes to make sure we have the right file?

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 import imap_data_access
-from imap_data_access.file_validation import ScienceFilePath
+from imap_data_access.file_validation import ScienceFilePath, SPICEFilePath
 
 
 def test_extract_filename_components():
@@ -169,3 +169,15 @@ def test_generate_from_inputs():
         "imap/mag/l0/2021/01/imap_mag_l0_raw_20210101-repoint00001_v001.pkts"
     )
     assert sfm.construct_path() == expected_output
+
+
+def test_spice_file_path():
+    """Tests the ``SPICEFilePath`` class."""
+    file_path = SPICEFilePath("test.bc")
+    assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "imap/spice/ck/test.bc"
+    )
+
+    # Test a bad file extension too
+    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+        SPICEFilePath("test.txt")


### PR DESCRIPTION
# Change Summary

## Overview

This adds the ability to download and upload SPICE files to the SDC. There is a mapping based on the SPICE file extension to which subdirectory it will go to.

Also closes #23 because we are now always inferring the directory structure from the filename, even if a full path was given to the file.

```bash
# This for the new SPICE file
imap-data-access -v download imap_001.tf
# and this for issue 23
imap-data-access -v download imap_mag_l1a_burst-magi_20240314_v001.cdf
```


## Testing

I added a test_science_file and test_science_path now because we require explicit science file paths or SPICE paths for download/upload now, so this makes it easier to re-use during tests.