### PR TITLE
Add a way to add an api-key authentication to the upload request

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -28,6 +28,7 @@ config = {
     "DATA_ACCESS_URL": os.getenv("IMAP_DATA_ACCESS_URL")
     or "https://api.dev.imap-mission.com",
     "DATA_DIR": Path(os.getenv("IMAP_DATA_DIR") or Path.cwd() / "data"),
+    "API_KEY": os.getenv("IMAP_API_KEY"),
 }
 """Settings configuration dictionary.
 
@@ -36,6 +37,9 @@ DATA_DIR : This is where the file data is stored and organized by instrument and
     The default location is a 'data/' folder in the current working directory,
     "but this can be set on the command line using the --data-dir option, or through
     the environment variable IMAP_DATA_DIR.
+API_KEY : This is the API key used to authenticate with the data access API.
+    It can be set on the command line using the --api-key option, or through the
+    environment variable IMAP_API_KEY. It is only necessary for uploading files.
 """
 
 

--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -139,6 +139,11 @@ def main():
 
     Run the command line interface to the IMAP Data Access API.
     """
+    api_key_help = (
+        "API key to authenticate with the IMAP SDC. "
+        "This can also be set using the IMAP_API_KEY environment variable. "
+        "It is only necessary for uploading files."
+    )
     data_dir_help = (
         "Directory to use for reading and writing IMAP data. "
         "The default is a 'data/' folder in the "
@@ -176,6 +181,7 @@ def main():
         action="version",
         version=f"%(prog)s {imap_data_access.__version__}",
     )
+    parser.add_argument("--api-key", type=str, required=False, help=api_key_help)
     parser.add_argument("--data-dir", type=Path, required=False, help=data_dir_help)
     parser.add_argument("--url", type=str, required=False, help=url_help)
     # Logging level
@@ -288,6 +294,10 @@ def main():
     if args.url:
         # We got an explicit url from the command line
         imap_data_access.config["DATA_ACCESS_URL"] = args.url
+
+    if args.api_key:
+        # We got an explicit api key from the command line
+        imap_data_access.config["API_KEY"] = args.api_key
 
     # Now process through the respective function for the invoked command
     # (set with set_defaults on the subparsers above)

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -155,7 +155,7 @@ def query(
     return items
 
 
-def upload(file_path: Union[Path, str]) -> None:
+def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> None:
     """Upload a file to the data archive.
 
     Parameters
@@ -163,6 +163,9 @@ def upload(file_path: Union[Path, str]) -> None:
     file_path : pathlib.Path or str
         Path to the file to upload. It must be located within
         the ``imap_data_access.config["DATA_DIR"]`` directory.
+    api_key : str, optional
+        API key to authenticate with the data access API. If not provided,
+        the value from the IMAP_API_KEY environment variable will be used.
     """
     file_path = Path(file_path).resolve()
     if not file_path.exists():
@@ -185,10 +188,12 @@ def upload(file_path: Union[Path, str]) -> None:
     url += f"/upload/{upload_name}"
     logger.info("Uploading file %s to %s", file_path, url)
 
+    # Create a request header with the API key
+    api_key = api_key or imap_data_access.config["API_KEY"]
     # We send a GET request with the filename and the server
     # will respond with an s3 presigned URL that we can use
     # to upload the file to the data archive
-    request = urllib.request.Request(url, method="GET")
+    request = urllib.request.Request(url, method="GET", headers={"X-api-key": api_key})
 
     with _get_url_response(request) as response:
         # Retrieve the key for the upload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,3 +12,4 @@ def _set_global_config(monkeypatch: pytest.fixture, tmp_path: pytest.fixture):
     monkeypatch.setitem(
         imap_data_access.config, "DATA_ACCESS_URL", "https://api.test.com"
     )
+    monkeypatch.setitem(imap_data_access.config, "API_KEY", "test-api-key")

--- a/tests/test_config_options.py
+++ b/tests/test_config_options.py
@@ -62,3 +62,31 @@ def test_url():
         text=True,
     )
     assert proc.stdout.strip() == "https://test.url"
+
+
+def test_api_key():
+    """Test that the api-key is set correctly."""
+    command = [
+        sys.executable,
+        "-c",
+        "import imap_data_access; print(imap_data_access.config['API_KEY'])",
+    ]
+    # Default import should be None
+    proc = subprocess.run(
+        command,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    expected = "None"
+    assert proc.stdout.strip() == expected
+
+    # Setting the environment variable should change the url
+    proc = subprocess.run(
+        command,
+        env={**os.environ, "IMAP_API_KEY": "test-api-key"},
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    assert proc.stdout.strip() == "test-api-key"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -294,6 +294,8 @@ def test_upload(mock_urlopen: unittest.mock.MagicMock, upload_file_path: str | P
     expected_url_encoded = "https://api.test.com/upload/a/b/test-file.txt"
     assert called_url == expected_url_encoded
     assert request_sent.method == "GET"
+    # An API key needs to be added to the header for uploads
+    assert request_sent.headers == {"X-api-key": "test-api-key"}
 
     # Verify that we put that response into our second request
     urlopen_call = mock_calls[1]


### PR DESCRIPTION
This adds an X-api-key header to the upload request. The api key can be set as an environment variable, through the command line, or through the config dictionary.