### PR TITLE
MNT(cli): Align hyphens/end-column separator in cli row separator

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -52,7 +52,7 @@ def _print_query_results_table(query_results: list[dict]):
         return
     format_string = "{:<10}|{:<10}|{:<10}|{:<10}|{:<10}|{:<7}|{:<50}|"
     # Add hyphens for a separator between header and data
-    hyphens = "-" * 111 + "|"
+    hyphens = "-" * 113 + "|"
     print(hyphens)
     header = [
         "Instrument",


### PR DESCRIPTION
There was an annoying mismatch before, so a quick fix to align things.

Before:
```
imap-data-access query --instrument mag --data-level l1a
Found [10] matching files
---------------------------------------------------------------------------------------------------------------|
Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |
---------------------------------------------------------------------------------------------------------------|
```