### PR TITLE
Fix api key used for uploads

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -22,7 +22,7 @@ __all__ = [
     "VALID_FILE_EXTENSION",
     "FILENAME_CONVENTION",
 ]
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 
 config = {

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -196,7 +196,8 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
     # We send a GET request with the filename and the server
     # will respond with an s3 presigned URL that we can use
     # to upload the file to the data archive
-    request = urllib.request.Request(url, method="GET", headers={"X-api-key": api_key})
+    headers = {"X-api-key": api_key} if api_key else {}
+    request = urllib.request.Request(url, method="GET", headers=headers)
 
     with _get_url_response(request) as response:
         # Retrieve the key for the upload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imap-data-access"
-version = "0.6.0"
+version = "0.6.1"
 description = "IMAP SDC Data Access"
 authors = [{name = "IMAP SDC Developers", email = "imap-sdc@lists.lasp.colorado.edu"}]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,3 @@ def _set_global_config(monkeypatch: pytest.fixture, tmp_path: pytest.fixture):
     monkeypatch.setitem(
         imap_data_access.config, "DATA_ACCESS_URL", "https://api.test.com"
     )
-    monkeypatch.setitem(imap_data_access.config, "API_KEY", "test-api-key")


### PR DESCRIPTION
# Change Summary

## Overview

I messed up, and didn't fully test the previous version I guess. There was an issue when NOT using an API-key, and we want users to be able to go through either route and let the server complain not our application.

There was an error converting None-type, so we need to explicitly make it an empty dictionary rather than adding {"Header-value": None} to the request.

I have added a more explicit test for the None/expected-string case now.

I have tested this on the dev server and all uploads/downloads worked for both science and spice files.