### PR TITLE
MNT: Update pyproject with explicit package resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,11 @@ repository = "https://github.com/IMAP-Science-Operations-Center/imap-data-access
 
 
 [project.optional-dependencies]
-dev = ["ruff"]
+dev = ["imap_data_access[test]", "pre-commit", "ruff"]
 test = ["pytest", "pytest-cov"]
 
+[tool.setuptools]
+packages = ["imap_data_access"]
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
# Change Summary

## Overview

When a `data/` directory is present it is ambiguous which modules/packages we want to release, so explicitly set this to be only "imap_data_access".

Add pre-commit and tests to the dev optional dependencies for initial installs.