### PR TITLE
FIX: Remove restriction on upload data directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The folder structure for data files within the IMAP SDC is rigidly
 defined, so the data access will mimic that structure to make sure
 all data is stored in the same heirarchical structure as the SDC.
 This will enable seamless transition between a user's local system
-and the SDC.
+and the SDC. This is only used for downloads.
 
 A user's root data location can be specified as an environment
 variable ``IMAP_DATA_DIR`` or through a configuration dictionary

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -164,8 +164,7 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
     Parameters
     ----------
     file_path : pathlib.Path or str
-        Path to the file to upload. It must be located within
-        the ``imap_data_access.config["DATA_DIR"]`` directory.
+        Path to the file to upload.
     api_key : str, optional
         API key to authenticate with the data access API. If not provided,
         the value from the IMAP_API_KEY environment variable will be used.
@@ -174,21 +173,9 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
     if not file_path.exists():
         raise FileNotFoundError(file_path)
 
-    if not file_path.is_relative_to(imap_data_access.config["DATA_DIR"]):
-        raise ValueError(
-            f"File {file_path} is not within the data directory: "
-            f"{imap_data_access.config['DATA_DIR']}"
-        )
-
-    # Strip off the data directory to get the upload path + name
-    # Must be posix style for the URL
-    upload_name = str(
-        file_path.relative_to(imap_data_access.config["DATA_DIR"]).as_posix()
-    )
-
     url = f"{imap_data_access.config['DATA_ACCESS_URL']}"
     # The upload name needs to be given as a path parameter
-    url += f"/upload/{upload_name}"
+    url += f"/upload/{file_path.name}"
     logger.info("Uploading file %s to %s", file_path, url)
 
     # Create a request header with the API key

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -234,25 +234,6 @@ def test_upload_no_file(mock_urlopen: unittest.mock.MagicMock):
     assert mock_urlopen.call_count == 0
 
 
-def test_upload_not_relative_to_base(
-    monkeypatch: pytest.fixture, mock_urlopen: unittest.mock.MagicMock
-):
-    """Test a call to the upload API for a file stored in a bad location.
-
-    Parameters
-    ----------
-    monkeypatch :  pytest.fixture
-        Used to set the ``DATA_DIR`` during tests
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    """
-    # Change the base directory to something else temporarily
-    monkeypatch.setitem(imap_data_access.config, "DATA_DIR", Path.cwd() / "/a/b/c")
-    with pytest.raises(ValueError, match="File"):
-        imap_data_access.upload(Path(__file__))
-    assert mock_urlopen.call_count == 0
-
-
 @pytest.mark.parametrize(
     "upload_file_path", ["a/b/test-file.txt", Path("a/b/test-file.txt")]
 )
@@ -307,7 +288,7 @@ def test_upload(
     urlopen_call = mock_calls[0]
     request_sent = urlopen_call.args[0]
     called_url = request_sent.full_url
-    expected_url_encoded = "https://api.test.com/upload/a/b/test-file.txt"
+    expected_url_encoded = "https://api.test.com/upload/test-file.txt"
     assert called_url == expected_url_encoded
     assert request_sent.method == "GET"
     # An API key needs to be added to the header for uploads


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

Our APIs don't require the full path anymore, they can use just the filename and infer the directory structure. This is helpful for the upload to be able to upload a file from the current working directory.

```python
imap-data-access -v upload imap_mag_l1a_burst-magi_20240314_v007.cdf 
INFO:imap_data_access.io:Uploading file /Users/grlu5547/code/imap/imap-data-access/data/imap/mag/l1a/2024/03/imap_mag_l1a_burst-magi_20240314_v007.cdf to https://api.dev.imap-mission.com/upload/imap_mag_l1a_burst-magi_20240314_v007.cdf
HTTP Error: 409 - Conflict
Server Message: "imap/mag/l1a/2024/03/imap_mag_l1a_burst-magi_20240314_v007.cdf already exists."
```

closes #41 