### PR TITLE
API demo notebook

### DIFF
--- a/api_demo.ipynb
+++ b/api_demo.ipynb
@@ -1,0 +1,671 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd5f888d-8589-4385-ac6e-19899bc4f1e2",
+   "metadata": {},
+   "source": [
+    "# IMAP Data Access API\n",
+    "\n",
+    "The IMAP SDC provides a Data Access API to **query**, **download**, and **upload** data. There are three ways to use the API:\n",
+    "\n",
+    "1. The `imap-data-access` command-line utility\n",
+    "2. The `imap_data_access` python package\n",
+    "3. Calls to the REST API directly\n",
+    "\n",
+    "This notebook provies instructions and examples of how to use the command-line utility and python package. *For information on how to use the REST API directly, see https://imap-processing.readthedocs.io/en/latest/data-access-api/index.html.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91a25008-383e-4955-a488-505d2979aa69",
+   "metadata": {},
+   "source": [
+    "## Data Directory\n",
+    "\n",
+    "Before using the API, it is important to note that the folder structure for data files within the IMAP SDC is rigidly defined, so the data access will mimic that structure to make sure all data is stored in the same heirarchical structure as the SDC. This will enable seamless transition between a user's local system and the SDC.\n",
+    "\n",
+    "The directory structure is as follows:\n",
+    "\n",
+    "```\n",
+    "<IMAP_DATA_DIR>/\n",
+    "  imap/\n",
+    "    <instrument>/\n",
+    "      <data_level>/\n",
+    "        <year>/\n",
+    "          <month>/\n",
+    "            <filename>\n",
+    "```\n",
+    "\n",
+    "for example:\n",
+    "\n",
+    "```\n",
+    "/data/\n",
+    "  imap/\n",
+    "    swe/\n",
+    "      l0/\n",
+    "        2024/\n",
+    "          01/\n",
+    "            imap_swe_l0_sci_20240105_v001.pkts\n",
+    "```\n",
+    "\n",
+    "By default, the `<IMAP_DATA_DIR>` is the user's current working directory. However, this can be changed by setting the `IMAP_DATA_DIR` environment variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "81113947-cb51-43b8-9a4e-22b68190bf45",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: IMAP_DATA_DIR=/Users/mabo8927/imap_data\n",
+      "/Users/mabo8927/imap_data\n"
+     ]
+    }
+   ],
+   "source": [
+    "!mkdir -p /Users/mabo8927/imap_data/\n",
+    "%env IMAP_DATA_DIR=/Users/mabo8927/imap_data\n",
+    "!echo $IMAP_DATA_DIR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb3324a4-6a31-44d3-9e10-d353dbee74e7",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "The API can be installed via `pip`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fb1b82d5-73d3-437e-b25d-c519c6ea1f7a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: imap-data-access in /Users/mabo8927/Desktop/envs/poetry/lib/python3.9/site-packages (0.7.0)\n",
+      "imap-data-access 0.7.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install imap-data-access\n",
+    "!imap-data-access --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee751d1f-4958-42ef-8449-9eb60a9bc1e0",
+   "metadata": {},
+   "source": [
+    "We leave it as an exercise to the user to install the package into their software environment of choice."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41582a62-1ecc-4a66-b939-23671821d28b",
+   "metadata": {},
+   "source": [
+    "## Command Line Utility\n",
+    "\n",
+    "The following section shows examples of how to use the API via the `imap-data-access` command line utility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "22def29d-9d87-4b18-897e-e28147d67091",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access [-h] [--version] [--api-key API_KEY]\n",
+      "                        [--data-dir DATA_DIR] [--url URL] [--debug] [-v]\n",
+      "                        {download,query,upload} ...\n",
+      "\n",
+      "This command line program accesses the IMAP SDC APIs to query, download, and\n",
+      "upload data files.\n",
+      "\n",
+      "positional arguments:\n",
+      "  {download,query,upload}\n",
+      "    download            Download a file from the IMAP SDC to the locally\n",
+      "                        configured data directory.\n",
+      "    query               Query the IMAP SDC for files matching the query\n",
+      "                        parameters. The query parameters are optional, but at\n",
+      "                        least one must be provided.\n",
+      "    upload              Upload a file to the IMAP SDC. This must be the full\n",
+      "                        path to the file. E.g.\n",
+      "                        imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  --version             show program's version number and exit\n",
+      "  --api-key API_KEY     API key to authenticate with the IMAP SDC. This can\n",
+      "                        also be set using the IMAP_API_KEY environment\n",
+      "                        variable. It is only necessary for uploading files.\n",
+      "  --data-dir DATA_DIR   Directory to use for reading and writing IMAP data.\n",
+      "                        The default is a 'data/' folder in the current working\n",
+      "                        directory. This can also be set using the\n",
+      "                        IMAP_DATA_DIR environment variable.\n",
+      "  --url URL             URL of the IMAP SDC API. The default is\n",
+      "                        https://api.dev.imap-mission.com. This can also be set\n",
+      "                        using the IMAP_DATA_ACCESS_URL environment variable.\n",
+      "  --debug               Print lots of debugging statements\n",
+      "  -v, --verbose         Add verbose output\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show help documentation\n",
+    "!imap-data-access -h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26e268c9-4366-4835-8783-0c6c362ab918",
+   "metadata": {},
+   "source": [
+    "#### Querying"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "74ffae35-e2c8-4bf4-9b90-34c225c057e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access query [-h]\n",
+      "                              [--instrument {codice,glows,hi,hit,idex,lo,mag,swapi,swe,ultra}]\n",
+      "                              [--data-level DATA_LEVEL]\n",
+      "                              [--descriptor DESCRIPTOR]\n",
+      "                              [--start-date START_DATE] [--end-date END_DATE]\n",
+      "                              [--repointing REPOINTING] [--version VERSION]\n",
+      "                              [--extension EXTENSION]\n",
+      "                              [--output-format {table,json}]\n",
+      "\n",
+      "Query the IMAP SDC for files matching the query parameters. The query\n",
+      "parameters are optional, but at least one must be provided.\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  --instrument {codice,glows,hi,hit,idex,lo,mag,swapi,swe,ultra}\n",
+      "                        Name of the instrument\n",
+      "  --data-level DATA_LEVEL\n",
+      "                        Data level of the product (l0, l1a, l2, etc.)\n",
+      "  --descriptor DESCRIPTOR\n",
+      "                        Descriptor of the product (raw, burst, etc.)\n",
+      "  --start-date START_DATE\n",
+      "                        Start date in YYYYMMDD format\n",
+      "  --end-date END_DATE   End date in YYYYMMDD format\n",
+      "  --repointing REPOINTING\n",
+      "                        Repointing number (int)\n",
+      "  --version VERSION     Version of the product in the format 'v001'\n",
+      "  --extension EXTENSION\n",
+      "                        File extension (cdf, pkts)\n",
+      "  --output-format {table,json}\n",
+      "                        How to format the output, default is 'table'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show query help documentation\n",
+    "!imap-data-access query -h"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b9abeb02-f930-4461-956f-1d3e93092332",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [7] matching files\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "glows     |l0        |raw       |20110921  |          |v001   |imap_glows_l0_raw_20110921_v001.pkts              |\n",
+      "glows     |l1a       |de        |20110920  |          |v001   |imap_glows_l1a_de_20110920_v001.cdf               |\n",
+      "glows     |l1a       |hist      |20110920  |          |v001   |imap_glows_l1a_hist_20110920_v001.cdf             |\n",
+      "glows     |l1a       |hist      |20110921  |          |v001   |imap_glows_l1a_hist_20110921_v001.cdf             |\n",
+      "glows     |l1b       |de        |20110920  |          |v001   |imap_glows_l1b_de_20110920_v001.cdf               |\n",
+      "glows     |l1b       |hist      |20110920  |          |v001   |imap_glows_l1b_hist_20110920_v001.cdf             |\n",
+      "glows     |l1b       |hist      |20110921  |          |v001   |imap_glows_l1b_hist_20110921_v001.cdf             |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Query with a single parameter\n",
+    "!imap-data-access query --instrument glows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a4c487a5-9126-443c-9a99-f871f8315fc1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [2] matching files\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "glows     |l1a       |hist      |20110920  |          |v001   |imap_glows_l1a_hist_20110920_v001.cdf             |\n",
+      "glows     |l1a       |hist      |20110921  |          |v001   |imap_glows_l1a_hist_20110921_v001.cdf             |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Query with multiple parameters\n",
+    "!imap-data-access query --instrument glows --data-level l1a --descriptor hist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "114cc8ea-634c-46d8-a350-b71d1ebd5588",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'file_path': 'imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf', 'instrument': 'glows', 'data_level': 'l1a', 'descriptor': 'hist', 'start_date': '20110920', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-07-09 15:42:23'}, {'file_path': 'imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf', 'instrument': 'glows', 'data_level': 'l1a', 'descriptor': 'hist', 'start_date': '20110921', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-07-09 15:42:24'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Change the output format\n",
+    "!imap-data-access query --instrument glows --data-level l1a --descriptor hist --output-format json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8616a4cf-30bc-4f9f-a8f1-a3393a5c8448",
+   "metadata": {},
+   "source": [
+    "#### Download a file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "514544ff-538f-4d63-9965-7400b1e8fc9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access download [-h] file_path\n",
+      "\n",
+      "Download a file from the IMAP SDC to the locally configured data directory.\n",
+      "\n",
+      "positional arguments:\n",
+      "  file_path   This must be the full path to the file. E.g.\n",
+      "              imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help  show this help message and exit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show download help documentation\n",
+    "!imap-data-access download -h"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c34122dd-9151-4722-93cc-3933d7b55aca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf\n",
+      "-rw-r--r--  1 mabo8927  2260  6590261 Jul 31 14:53 /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download a file\n",
+    "!imap-data-access download imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf\n",
+    "\n",
+    "# Check to see that the file exists\n",
+    "!ls -lt $IMAP_DATA_DIR/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4323aba-87c7-4f54-8fe8-c760a130193e",
+   "metadata": {},
+   "source": [
+    "#### Upload a file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "94aa436a-aaad-4e33-b7c8-eb4aa95a84b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access upload [-h] file_path\n",
+      "\n",
+      "Upload a file to the IMAP SDC. This must be the full path to the file. E.g.\n",
+      "imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "\n",
+      "positional arguments:\n",
+      "  file_path   This must be the full path to the file. E.g.\n",
+      "              imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help  show this help message and exit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show upload help documentation\n",
+    "!imap-data-access upload -h"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4a4ad566-a418-4a88-a4d7-9bc51f622fc6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [7] matching files\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "codice    |l0        |hskp      |20240610  |          |v001   |imap_codice_l0_hskp_20240610_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240610  |          |v100   |imap_codice_l0_hskp_20240610_v100.pkts            |\n",
+      "codice    |l0        |hskp      |20240610  |          |v200   |imap_codice_l0_hskp_20240610_v200.pkts            |\n",
+      "codice    |l0        |hskp      |20240610  |          |v210   |imap_codice_l0_hskp_20240610_v210.pkts            |\n",
+      "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Show the current CoDICE files to see what is there\n",
+    "!imap-data-access query --instrument codice --descriptor hskp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b6e80ccd-3555-4deb-be18-32767a076613",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully uploaded the file to the IMAP SDC\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Make sure file to upload is correctly placed in the data directory\n",
+    "!mkdir -p $IMAP_DATA_DIR/imap/codice/l0/2024/07/\n",
+    "!cp $IMAP_DATA_DIR/imap_codice_l0_hskp_20240720_v001.pkts $IMAP_DATA_DIR/imap/codice/l0/2024/07/\n",
+    "\n",
+    "# Upload the file\n",
+    "!imap-data-access upload $IMAP_DATA_DIR/imap/codice/l0/2024/07/imap_codice_l0_hskp_20240720_v001.pkts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "d923b744-066f-4538-bf91-3a20f96aa88a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [8] matching files\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n",
+      "codice    |l0        |hskp      |20240610  |          |v001   |imap_codice_l0_hskp_20240610_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240610  |          |v100   |imap_codice_l0_hskp_20240610_v100.pkts            |\n",
+      "codice    |l0        |hskp      |20240610  |          |v200   |imap_codice_l0_hskp_20240610_v200.pkts            |\n",
+      "codice    |l0        |hskp      |20240610  |          |v210   |imap_codice_l0_hskp_20240610_v210.pkts            |\n",
+      "codice    |l0        |hskp      |20240720  |          |v001   |imap_codice_l0_hskp_20240720_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
+      "-----------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check the CoDICE files to see that it was uploaded\n",
+    "!imap-data-access query --instrument codice --descriptor hskp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9226db66-da23-449d-aec9-ee0cf30e8742",
+   "metadata": {},
+   "source": [
+    "## Python Package\n",
+    "The following section shows examples of how to use the API via the `imap_data_access` Python package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b4548bc2-591e-480c-bcc0-6e7b8206a928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import the package\n",
+    "import imap_data_access"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd4a0ad5-eb19-493c-af42-a78abea029c5",
+   "metadata": {},
+   "source": [
+    "The `<IMAP_DATA_DIR>` can be set via the `config` dictionary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d4a7cf75-ac18-4dea-9761-bc9a6824b2d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imap_data_access.config[\"DATA_DIR\"] = '/Users/mabo8927/imap_data'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2480140-9f8f-4634-ac35-b7a59c91f42a",
+   "metadata": {},
+   "source": [
+    "#### Querying"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "0bb7a88f-c6a9-40aa-adc0-a275505a75c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v000.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250502', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-07-16 10:27:13'}\n",
+      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250502', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-16 10:29:33'}\n",
+      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250511_v000.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250511', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-07-19 16:34:35'}\n",
+      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250511_v001.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250511', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-19 16:36:32'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = imap_data_access.query(instrument=\"mag\", data_level=\"l0\")\n",
+    "for result in results:\n",
+    "    print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05e57918-b537-4bdd-891c-62af73c0f251",
+   "metadata": {},
+   "source": [
+    "#### Download a file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "05668477-e308-4762-8e7b-77b8a6475eda",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
+     ]
+    }
+   ],
+   "source": [
+    "file_path = imap_data_access.download(\"imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\")\n",
+    "print(file_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53583575-ff2d-4e03-884c-9e4ccd571691",
+   "metadata": {},
+   "source": [
+    "#### Upload a file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "826101e2-ef0e-4ddb-8431-b6d2999a0721",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure file to upload is correctly placed in the data directory\n",
+    "!cp $IMAP_DATA_DIR/imap_codice_l0_hskp_20240721_v001.pkts $IMAP_DATA_DIR/imap/codice/l0/2024/07/\n",
+    "\n",
+    "imap_data_access.upload(\"/Users/mabo8927/imap_data/imap/codice/l0/2024/07/imap_codice_l0_hskp_20240721_v001.pkts\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "2143b551-dc1c-4d3f-ac8b-01f28e7ec1d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'file_path': 'imap/codice/l0/2024/07/imap_codice_l0_hskp_20240721_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'hskp', 'start_date': '20240721', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-31 20:54:57'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check to see if file was uploaded\n",
+    "results = imap_data_access.query(instrument=\"codice\", descriptor=\"hskp\", start_date=\"20240721\", end_date=\"20240722\")\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb21e6a3-fa17-4be0-a3c7-6ae998e701c1",
+   "metadata": {},
+   "source": [
+    "## Future work\n",
+    "\n",
+    "The SDC continues to develop the API for the greater needs of the IMAP community. We currently have plans to add the following features (subject to change):\n",
+    "\n",
+    "- Add `filename` as a query parameter to return information for a particular file\n",
+    "- Add `today` as a query parameter to return list of files that were acquired in the last 24 hours\n",
+    "- Add `days_ago=N` as a query parameter to return a list of file that were acquired in the last `N` days\n",
+    "- Add ability to upload ancillary files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62b4dffe-ca0e-493a-b57d-428ab211c064",
+   "metadata": {},
+   "source": [
+    "## Ideas/requests for other API features or endpoints?\n",
+    "\n",
+    "We would like to gather user feedback on how we could improve or expand upon the existing API. What API endpoints could we add? What kind of information would be useful to get from the API?\n",
+    "\n",
+    "For feature requests and bug reports, please open a [new issue](https://github.com/IMAP-Science-Operations-Center/imap-data-access/issues/new) in the Data Access API repository."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -348,17 +348,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf\n",
-      "-rw-r--r--  1 mabo8927  2260  6590261 Jul 31 14:53 /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf\n"
+      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf\n",
+      "-rw-r--r--  1 mabo8927  2260  8183501 Jul 31 16:43 /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf\n"
      ]
     }
    ],
    "source": [
     "# Download a file\n",
-    "!imap-data-access download imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf\n",
+    "!imap-data-access download imap_glows_l1a_hist_20110921_v001.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
-    "!ls -lt $IMAP_DATA_DIR/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf"
+    "!ls -lt $IMAP_DATA_DIR/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf"
    ]
   },
   {
@@ -408,7 +408,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [7] matching files\n",
+      "Found [10] matching files\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
       "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
@@ -416,6 +416,9 @@
       "codice    |l0        |hskp      |20240610  |          |v100   |imap_codice_l0_hskp_20240610_v100.pkts            |\n",
       "codice    |l0        |hskp      |20240610  |          |v200   |imap_codice_l0_hskp_20240610_v200.pkts            |\n",
       "codice    |l0        |hskp      |20240610  |          |v210   |imap_codice_l0_hskp_20240610_v210.pkts            |\n",
+      "codice    |l0        |hskp      |20240720  |          |v001   |imap_codice_l0_hskp_20240720_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240721  |          |v001   |imap_codice_l0_hskp_20240721_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240722  |          |v001   |imap_codice_l0_hskp_20240722_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
       "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
@@ -443,12 +446,8 @@
     }
    ],
    "source": [
-    "# Make sure file to upload is correctly placed in the data directory\n",
-    "!mkdir -p $IMAP_DATA_DIR/imap/codice/l0/2024/07/\n",
-    "!cp $IMAP_DATA_DIR/imap_codice_l0_hskp_20240720_v001.pkts $IMAP_DATA_DIR/imap/codice/l0/2024/07/\n",
-    "\n",
     "# Upload the file\n",
-    "!imap-data-access upload $IMAP_DATA_DIR/imap/codice/l0/2024/07/imap_codice_l0_hskp_20240720_v001.pkts"
+    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_hskp_20240723_v001.pkts"
    ]
   },
   {
@@ -461,7 +460,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [8] matching files\n",
+      "Found [11] matching files\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
       "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
@@ -470,6 +469,9 @@
       "codice    |l0        |hskp      |20240610  |          |v200   |imap_codice_l0_hskp_20240610_v200.pkts            |\n",
       "codice    |l0        |hskp      |20240610  |          |v210   |imap_codice_l0_hskp_20240610_v210.pkts            |\n",
       "codice    |l0        |hskp      |20240720  |          |v001   |imap_codice_l0_hskp_20240720_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240721  |          |v001   |imap_codice_l0_hskp_20240721_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240722  |          |v001   |imap_codice_l0_hskp_20240722_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240723  |          |v001   |imap_codice_l0_hskp_20240723_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
       "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
@@ -517,7 +519,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imap_data_access.config[\"DATA_DIR\"] = '/Users/mabo8927/imap_data'"
+    "from pathlib import Path\n",
+    "imap_data_access.config[\"DATA_DIR\"] = Path.home() / \"imap_data\""
    ]
   },
   {
@@ -574,7 +577,7 @@
     }
    ],
    "source": [
-    "file_path = imap_data_access.download(\"imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\")\n",
+    "file_path = imap_data_access.download(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
     "print(file_path)"
    ]
   },
@@ -588,20 +591,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "826101e2-ef0e-4ddb-8431-b6d2999a0721",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Make sure file to upload is correctly placed in the data directory\n",
-    "!cp $IMAP_DATA_DIR/imap_codice_l0_hskp_20240721_v001.pkts $IMAP_DATA_DIR/imap/codice/l0/2024/07/\n",
-    "\n",
-    "imap_data_access.upload(\"/Users/mabo8927/imap_data/imap/codice/l0/2024/07/imap_codice_l0_hskp_20240721_v001.pkts\")"
+    "imap_data_access.upload(f\"{Path.home()}/imap_data/imap_codice_l0_hskp_20240724_v001.pkts\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "2143b551-dc1c-4d3f-ac8b-01f28e7ec1d5",
    "metadata": {},
    "outputs": [
@@ -609,13 +609,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'file_path': 'imap/codice/l0/2024/07/imap_codice_l0_hskp_20240721_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'hskp', 'start_date': '20240721', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-31 20:54:57'}]\n"
+      "[{'file_path': 'imap/codice/l0/2024/07/imap_codice_l0_hskp_20240724_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'hskp', 'start_date': '20240724', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-31 22:58:50'}]\n"
      ]
     }
    ],
    "source": [
     "# Check to see if file was uploaded\n",
-    "results = imap_data_access.query(instrument=\"codice\", descriptor=\"hskp\", start_date=\"20240721\", end_date=\"20240722\")\n",
+    "results = imap_data_access.query(instrument=\"codice\", descriptor=\"hskp\", start_date=\"20240724\", end_date=\"20240725\")\n",
     "print(results)"
    ]
   },

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -93,7 +93,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: imap-data-access in /Users/mabo8927/Desktop/envs/poetry/lib/python3.9/site-packages (0.7.0)\n",
+      "Collecting imap-data-access\n",
+      "  Using cached imap_data_access-0.7.0-py3-none-any.whl\n",
+      "Installing collected packages: imap-data-access\n",
+      "Successfully installed imap-data-access-0.7.0\n",
       "imap-data-access 0.7.0\n"
      ]
     }
@@ -408,7 +411,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [10] matching files\n",
+      "Found [12] matching files\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
       "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
@@ -419,6 +422,8 @@
       "codice    |l0        |hskp      |20240720  |          |v001   |imap_codice_l0_hskp_20240720_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240721  |          |v001   |imap_codice_l0_hskp_20240721_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240722  |          |v001   |imap_codice_l0_hskp_20240722_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240723  |          |v001   |imap_codice_l0_hskp_20240723_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240724  |          |v001   |imap_codice_l0_hskp_20240724_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
       "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
@@ -447,7 +452,7 @@
    ],
    "source": [
     "# Upload the file\n",
-    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_hskp_20240723_v001.pkts"
+    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_hskp_20240725_v001.pkts"
    ]
   },
   {
@@ -460,7 +465,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [11] matching files\n",
+      "Found [13] matching files\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
       "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
       "-----------------------------------------------------------------------------------------------------------------|\n",
@@ -472,6 +477,8 @@
       "codice    |l0        |hskp      |20240721  |          |v001   |imap_codice_l0_hskp_20240721_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240722  |          |v001   |imap_codice_l0_hskp_20240722_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240723  |          |v001   |imap_codice_l0_hskp_20240723_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240724  |          |v001   |imap_codice_l0_hskp_20240724_v001.pkts            |\n",
+      "codice    |l0        |hskp      |20240725  |          |v001   |imap_codice_l0_hskp_20240725_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
       "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
       "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
@@ -486,6 +493,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b1d2937f-95d2-4b05-bf9a-12010a28ac6d",
+   "metadata": {},
+   "source": [
+    "#### Bonus: Let's see it in action in AWS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b3b89956-b7d8-46f6-8b91-ebff19fe7693",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully uploaded the file to the IMAP SDC\n"
+     ]
+    }
+   ],
+   "source": [
+    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_lo-counters-singles_20240429_v001.pkts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9226db66-da23-449d-aec9-ee0cf30e8742",
    "metadata": {},
    "source": [
@@ -495,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "b4548bc2-591e-480c-bcc0-6e7b8206a928",
    "metadata": {},
    "outputs": [],
@@ -514,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "d4a7cf75-ac18-4dea-9761-bc9a6824b2d0",
    "metadata": {},
    "outputs": [],
@@ -533,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "0bb7a88f-c6a9-40aa-adc0-a275505a75c6",
    "metadata": {},
    "outputs": [
@@ -564,7 +597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "05668477-e308-4762-8e7b-77b8a6475eda",
    "metadata": {},
    "outputs": [
@@ -591,17 +624,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "id": "826101e2-ef0e-4ddb-8431-b6d2999a0721",
    "metadata": {},
    "outputs": [],
    "source": [
-    "imap_data_access.upload(f\"{Path.home()}/imap_data/imap_codice_l0_hskp_20240724_v001.pkts\")"
+    "imap_data_access.upload(f\"{Path.home()}/imap_data/imap_codice_l0_hskp_20240726_v001.pkts\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "id": "2143b551-dc1c-4d3f-ac8b-01f28e7ec1d5",
    "metadata": {},
    "outputs": [
@@ -609,14 +642,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'file_path': 'imap/codice/l0/2024/07/imap_codice_l0_hskp_20240724_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'hskp', 'start_date': '20240724', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-31 22:58:50'}]\n"
+      "[{'file_path': 'imap/codice/l0/2024/07/imap_codice_l0_hskp_20240726_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'hskp', 'start_date': '20240726', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-08-01 22:27:27'}]\n"
      ]
     }
    ],
    "source": [
     "# Check to see if file was uploaded\n",
-    "results = imap_data_access.query(instrument=\"codice\", descriptor=\"hskp\", start_date=\"20240724\", end_date=\"20240725\")\n",
+    "results = imap_data_access.query(instrument=\"codice\", descriptor=\"hskp\", start_date=\"20240726\", end_date=\"20240727\")\n",
     "print(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4afad809-a537-4227-ba1c-f8dadd4a456d",
+   "metadata": {},
+   "source": [
+    "#### Bonus: validate/construct a file path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "5615873a-22f1-4921-8e06-bb9db1173f62",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20250502\n",
+      "raw\n",
+      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
+     ]
+    }
+   ],
+   "source": [
+    "science_file = imap_data_access.ScienceFilePath(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
+    "print(science_file.start_date)\n",
+    "print(science_file.descriptor)\n",
+    "\n",
+    "filepath = science_file.construct_path()\n",
+    "print(filepath)"
    ]
   },
   {


### PR DESCRIPTION
# Change Summary

## Overview
This PR adds a notebook that provides a demo of how to use the `data-access-api` command line tool and `data_access_api` python package. This is intended to be presented at the IMAP Science Team Meeting on August 2nd.

There is one piece of the notebook that has a hard-coded path to a directory path on my particular system. I wasn't sure how to avoid this. We will need to specify a local directory in order for file uploads to work.

## New Dependencies
<!--List any new dependencies introduced by these changes-->
We could possibly add `jupyter` as a dependency to this repo if we want users to be able to run this notebook themselves. Currently, I assume the if the user wants to do this, they will have installed `jupyter` into their environment by other means.

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- `api_demo.ipynb`
   - The notebook
