### PR TITLE
Error when querying "latest" version when no data exists in database

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -173,7 +173,7 @@ def query(
         logger.debug("Decoded JSON: %s", items)
 
     # if latest version was included in search then filter returned query for largest.
-    if (version == "latest") and (len(items) > 0):
+    if (version == "latest") and items:
         max_version = max(int(each_dict.get("version")[1:4]) for each_dict in items)
         items = [
             each_dict

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -173,7 +173,7 @@ def query(
         logger.debug("Decoded JSON: %s", items)
 
     # if latest version was included in search then filter returned query for largest.
-    if version == "latest":
+    if (version == "latest") and (len(items) > 0):
         max_version = max(int(each_dict.get("version")[1:4]) for each_dict in items)
         items = [
             each_dict


### PR DESCRIPTION
# Change Summary

## Overview
When querying the database with `version` == `latest`, but no matching data exists, Python errors. This change fixes the issue.

## New Dependencies
N/A

## New Files
N/A

## Deleted Files
N/A

## Updated Files
- `io.py`
   - add check to make sure at least one data point exists before looking for latest version

## Testing
Tested locally with and without data
