### PR TITLE
Bug Fix For CLI crash

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -20,9 +20,8 @@ import logging
 import os
 from pathlib import Path
 
-from file_validation import ScienceFilePath
-
 import imap_data_access
+from imap_data_access.file_validation import ScienceFilePath
 
 
 def _download_parser(args: argparse.Namespace):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+"""Tests for the CLI options."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from imap_data_access import cli
+
+
+def test_cli_works():
+    """Smoke test for the CLI module making sure it is callable."""
+    with mock.patch.object(sys, "argv", ["imap-data-access", "-h"]):
+        # Should have a 0 SystemExit return code if successful
+        with pytest.raises(SystemExit, match="0"):
+            cli.main()


### PR DESCRIPTION
# Fix for the module_not_found error when installing updated Cli

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Fixing the import statement and adding a test file for the cli so the error does not slip through again.

Closes #81 
## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
-test_cli.py


## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- cli.py

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
