### PR TITLE
MNT: Follow 307 redirects from AWS

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -37,11 +37,18 @@ def _get_url_response(request: urllib.request.Request):
             yield response
 
     except HTTPError as e:
-        message = (
-            f"HTTP Error: {e.code} - {e.reason}\n"
-            f"Server Message: {e.read().decode('utf-8')}"
-        )
-        raise IMAPDataAccessError(message) from e
+        if e.status == 307:
+            # If the server is redirecting us, we need to follow the redirect
+            request.full_url = e.headers["Location"]
+            with _get_url_response(request) as response:
+                yield response
+        else:
+            message = (
+                f"HTTP Error: {e.code} - {e.reason}\n"
+                f"Server Message: {e.read().decode('utf-8')}"
+            )
+            raise IMAPDataAccessError(message) from e
+
     except URLError as e:
         message = f"URL Error: {e.reason}"
         raise IMAPDataAccessError(message) from e


### PR DESCRIPTION
When deploying a new bucket in a non us-east-1 region, it can take time to propagate to propagate the DNS records and thus AWS will give us a 307 redirect to a region-specific endpoint. This only matters for PUT requests because those aren't supposed to be followed by default and therefore Python raises an HTTPError with a 307 code that we catch. So we can do the redirect ourselves from within there.

The attempted fix in `sds-data-manager` didn't fix the issue apparently when deploying fresh this morning. This does fix the issue from within `imap-data-access` instead.