### PR TITLE
MNT/FIX: Removing imap/ prefix from SPICE files

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -354,5 +354,5 @@ class SPICEFilePath:
         spice_dir = imap_data_access.config["DATA_DIR"] / "spice"
         subdir = _SPICE_DIR_MAPPING[self.filename.suffix]
         # Use the file suffix to determine the directory structure
-        # IMAP_DATA_DIR/imap/spice/<subdir>/filename
+        # IMAP_DATA_DIR/spice/<subdir>/filename
         return spice_dir / subdir / self.filename

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -351,7 +351,7 @@ class SPICEFilePath:
         Path
             Upload path
         """
-        spice_dir = imap_data_access.config["DATA_DIR"] / "imap/spice"
+        spice_dir = imap_data_access.config["DATA_DIR"] / "spice"
         subdir = _SPICE_DIR_MAPPING[self.filename.suffix]
         # Use the file suffix to determine the directory structure
         # IMAP_DATA_DIR/imap/spice/<subdir>/filename

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -175,7 +175,7 @@ def test_spice_file_path():
     """Tests the ``SPICEFilePath`` class."""
     file_path = SPICEFilePath("test.bc")
     assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "imap/spice/ck/test.bc"
+        "spice/ck/test.bc"
     )
 
     # Test a bad file extension too

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -84,7 +84,7 @@ def test_request_errors(mock_urlopen: unittest.mock.MagicMock):
         # Pathlib.Path object
         (Path(test_science_path), test_science_path),
         # SPICE file
-        ("test.bc", "imap/spice/ck/test.bc"),
+        ("test.bc", "spice/ck/test.bc"),
     ],
 )
 def test_download(


### PR DESCRIPTION
It is currently `/imap/spice/ck/...`
We are changing it to `/spice/ck/...`
and dropping the imap/ prefix to separate out spice into its own separate directory.