### PR TITLE
Add l2a and l2b to valid data levels

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -67,6 +67,8 @@ VALID_DATALEVELS = {
     "l1cb",
     "l1d",
     "l2",
+    "l2a",
+    "l2b",
     "l3",
     "l3a",
     "l3b",


### PR DESCRIPTION
# Change Summary

closes #98

## Overview
IDEX is now distinguishing its L2 data products as L2A and L2B.  The valid data levels should be updated to reflect this.

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_data_access/__init__.py
  - "l2a" and "l2b" strings were added to the "VALID_DATALEVELS" set

