### PR TITLE
Refactor file validation to handle spin and repoint file extensions

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -369,7 +369,7 @@ class SPICEFilePath:
         self.filename = Path(filename)
         if self.filename.suffix == ".csv":
             all_suffixes = self.filename.suffixes  # Returns ['.spin', '.csv']
-            self.file_extension = ''.join(all_suffixes)  # Returns '.spin.csv'
+            self.file_extension = "".join(all_suffixes)  # Returns '.spin.csv'
         else:
             self.file_extension = self.filename.suffix
 

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -318,6 +318,8 @@ _SPICE_DIR_MAPPING = {
     # ".bes": "ek",
     ".bpc": "pck",
     ".bsp": "spk",
+    ".repointing.csv": "repointing",
+    ".spin.csv": "spin",
     ".tf": "fk",
     # "ti": "ik",
     ".tls": "lsk",
@@ -365,8 +367,13 @@ class SPICEFilePath:
             SPICE data filename or file path.
         """
         self.filename = Path(filename)
+        if self.filename.suffix == ".csv":
+            all_suffixes = self.filename.suffixes  # Returns ['.spin', '.csv']
+            self.file_extension = ''.join(all_suffixes)  # Returns '.spin.csv'
+        else:
+            self.file_extension = self.filename.suffix
 
-        if self.filename.suffix not in _SPICE_DIR_MAPPING:
+        if self.file_extension not in _SPICE_DIR_MAPPING:
             raise self.InvalidSPICEFileError(
                 f"Invalid SPICE file. Expected file to have one of the following "
                 f"extensions {list(_SPICE_DIR_MAPPING.keys())}"
@@ -384,7 +391,7 @@ class SPICEFilePath:
             Upload path
         """
         spice_dir = imap_data_access.config["DATA_DIR"] / "spice"
-        subdir = _SPICE_DIR_MAPPING[self.filename.suffix]
+        subdir = _SPICE_DIR_MAPPING[self.file_extension]
         # Use the file suffix to determine the directory structure
         # IMAP_DATA_DIR/spice/<subdir>/filename
         return spice_dir / subdir / self.filename

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -184,11 +184,11 @@ def test_spice_file_path():
 
     # Test that spin and repoint goes into their own directories
     spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
-    assert spin_file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/spin/imap_2025_122_2025_122_01.spin.csv"
-    )
+    assert spin_file_path.construct_path() == imap_data_access.config[
+        "DATA_DIR"
+    ] / Path("spice/spin/imap_2025_122_2025_122_01.spin.csv")
 
     spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repointing.csv")
-    assert spin_file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/repointing/imap_2025_122_2025_122_01.repointing.csv"
-    )
+    assert spin_file_path.construct_path() == imap_data_access.config[
+        "DATA_DIR"
+    ] / Path("spice/repointing/imap_2025_122_2025_122_01.repointing.csv")

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -181,3 +181,14 @@ def test_spice_file_path():
     # Test a bad file extension too
     with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
         SPICEFilePath("test.txt")
+
+    # Test that spin and repoint goes into their own directories
+    spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
+    assert spin_file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "spice/spin/imap_2025_122_2025_122_01.spin.csv"
+    )
+
+    spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repointing.csv")
+    assert spin_file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "spice/repointing/imap_2025_122_2025_122_01.repointing.csv"
+    )


### PR DESCRIPTION
# Change Summary
closes #100

## Overview
Added paths for spin and repointing data in `spice/` directory on s3.

## Updated Files
- imap_data_access/file_validation.py
   - Added spin and repoint updates


## Testing
- tests/test_file_validation.py
