### PR TITLE
SPICE: fix repoint csv filepath

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -319,7 +319,7 @@ _SPICE_DIR_MAPPING = {
     ".bpc": "pck",
     ".bsp": "spk",
     ".mk": "mk",
-    ".repointing.csv": "repointing",
+    ".repoint.csv": "repointing",
     ".sff": "activities",
     ".spin.csv": "spin",
     ".tf": "fk",

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -188,10 +188,10 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("spice/spin/imap_2025_122_2025_122_01.spin.csv")
 
-    spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repoint.csv")
-    assert spin_file_path.construct_path() == imap_data_access.config[
+    repoint_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repoint.csv")
+    assert repoint_file_path.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/repointing/imap_2025_122_2025_122_01.repointing.csv")
+    ] / Path("spice/repointing/imap_2025_122_2025_122_01.repoint.csv")
 
     metakernel_file = SPICEFilePath("imap_yyyy_doy_e00.mk")
     assert metakernel_file.construct_path() == imap_data_access.config[

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -188,7 +188,7 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("spice/spin/imap_2025_122_2025_122_01.spin.csv")
 
-    spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repointing.csv")
+    spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repoint.csv")
     assert spin_file_path.construct_path() == imap_data_access.config[
         "DATA_DIR"
     ] / Path("spice/repointing/imap_2025_122_2025_122_01.repointing.csv")


### PR DESCRIPTION
# Change Summary
closes #110 
## Overview
MOC's repointing data's filename is `imap_2025_230_2025_230_01.repoint.csv`. This PR fixes to match it.

## Updated Files
- imap_data_access/file_validation.py
   - update SPICE directory mapping dict


## Testing
tests/test_file_validation.py
