### PR TITLE
MNT: Fix PyPI build error and update repoint folder to match it's filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload sdist result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sdist
           path: dist

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -319,7 +319,7 @@ _SPICE_DIR_MAPPING = {
     ".bpc": "pck",
     ".bsp": "spk",
     ".mk": "mk",
-    ".repoint.csv": "repointing",
+    ".repoint.csv": "repoint",
     ".sff": "activities",
     ".spin.csv": "spin",
     ".tf": "fk",

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -191,7 +191,7 @@ def test_spice_file_path():
     repoint_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repoint.csv")
     assert repoint_file_path.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/repointing/imap_2025_122_2025_122_01.repoint.csv")
+    ] / Path("spice/repoint/imap_2025_122_2025_122_01.repoint.csv")
 
     metakernel_file = SPICEFilePath("imap_yyyy_doy_e00.mk")
     assert metakernel_file.construct_path() == imap_data_access.config[


### PR DESCRIPTION
# Change Summary

## Overview
update repoint data's folder path from `spice/repointing` to `spice/repoint` to match its filename and also to match spin folder path.

## Updated Files
- imap_data_access/file_validation.py
   - update folder path
- .github/workflows/release.yml
   - updated version to fix build fails
## Testing
tests/test_file_validation.py
