### PR TITLE
Fixed some small bugs in ancillary file validation step

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -8,7 +8,11 @@ provides a convenient way to query the IMAP data archive and download data files
 import os
 from pathlib import Path
 
-from imap_data_access.file_validation import ScienceFilePath, SPICEFilePath
+from imap_data_access.file_validation import (
+    AncillaryFilePath,
+    ScienceFilePath,
+    SPICEFilePath,
+)
 from imap_data_access.io import download, query, upload
 
 __all__ = [
@@ -17,6 +21,7 @@ __all__ = [
     "upload",
     "ScienceFilePath",
     "SPICEFilePath",
+    "AncillaryFilePath",
     "VALID_INSTRUMENTS",
     "VALID_DATALEVELS",
     "VALID_FILE_EXTENSION",

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -556,8 +556,12 @@ class AncillaryFilePath(ScienceFilePath):
 
         if not ScienceFilePath.is_valid_date(self.start_date):
             error_message += "Invalid start date format. Please use YYYYMMDD format. \n"
-        if not ScienceFilePath.is_valid_date(self.end_date):
-            error_message += "Invalid end date format. Please use YYYYMMDD format. \n"
+
+        if self.end_date:
+            if not ScienceFilePath.is_valid_date(self.end_date):
+                error_message += (
+                    "Invalid end date format. Please use YYYYMMDD format. \n"
+                )
 
         return error_message
 
@@ -624,4 +628,5 @@ class AncillaryFilePath(ScienceFilePath):
             )
 
         components = match.groupdict()
+
         return components

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -628,5 +628,4 @@ class AncillaryFilePath(ScienceFilePath):
             )
 
         components = match.groupdict()
-
         return components

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 
 import imap_data_access
-from imap_data_access.file_validation import ScienceFilePath, SPICEFilePath
+from imap_data_access.file_validation import (
+    AncillaryFilePath,
+    ScienceFilePath,
+    SPICEFilePath,
+)
 
 
 def test_extract_filename_components():
@@ -202,3 +206,20 @@ def test_spice_file_path():
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
         "spice/activities/imap_yyyy_doy_hist_00.sff"
     )
+
+
+def test_ancillary_file_path_no_end_date():
+    """Tests the ``construct_path`` method with no end_date provided."""
+    anc_file = AncillaryFilePath.generate_from_inputs(
+        instrument="mag",
+        description="test",
+        start_time="20210101",
+        version="v001",
+        extension="cdf",
+    )
+
+    assert anc_file.validate_filename() == ""
+    expected_output = imap_data_access.config["DATA_DIR"] / Path(
+        "imap/ancillary/mag/imap_mag_test_20210101_v001.cdf"
+    )
+    assert anc_file.construct_path() == expected_output


### PR DESCRIPTION
This PR fixes some bugs I discovered while testing the downloading of ancillary files, namely adding in a missing import, and checking for a valid `end_date` only if one is supplied.