### PR TITLE
API demo notebook updates for Feb 2025 STM

### DIFF
--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -2,40 +2,26 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f28c0487",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "# IMAP Data Access API\n",
     "\n",
-    "The IMAP SDC provides a Data Access API to **query**, **download**, and **upload** data. There are three ways to use the API:\n",
+    "The IMAP SDC provides a Data Access API to **query** and **download** data. There are three ways to use the API:\n",
     "\n",
     "1. The `imap-data-access` command-line utility\n",
     "2. The `imap_data_access` python package\n",
     "3. Calls to the REST API directly\n",
     "\n",
     "This notebook provies instructions and examples of how to use the command-line utility and python package. *For information on how to use the REST API directly, see https://imap-processing.readthedocs.io/en/latest/data-access/index.html*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "454b8b53",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   },
+   }
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "## Data Directory\n",
     "\n",
@@ -66,968 +52,401 @@
     "```\n",
     "\n",
     "By default, the `<IMAP_DATA_DIR>` is the user's current working directory. However, this can be changed by setting the `IMAP_DATA_DIR` environment variable:"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "34486463",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: IMAP_DATA_DIR=/Users/mabo8927/imap_data\n",
-      "/Users/mabo8927/imap_data\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "!mkdir -p /Users/mabo8927/imap_data/\n",
     "%env IMAP_DATA_DIR=/Users/mabo8927/imap_data\n",
     "!echo $IMAP_DATA_DIR"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "5dc33983",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "## Installation\n",
     "\n",
     "The API can be installed via `pip`:"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "2e21f9fa",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting imap-data-access\n",
-      "  Using cached imap_data_access-0.13.1-py3-none-any.whl\n",
-      "Installing collected packages: imap-data-access\n",
-      "Successfully installed imap-data-access-0.13.1\n",
-      "\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
-      "imap-data-access 0.13.1\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "!pip install imap-data-access\n",
     "!imap-data-access --version"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "3cd2051d",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "We leave it as an exercise to the user to install the package into their software environment of choice."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a354d555",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   },
+   }
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "## Command Line Utility\n",
     "\n",
     "The following section shows examples of how to use the API via the `imap-data-access` command line utility."
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "b557418d",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "usage: imap-data-access [-h] [--version] [--api-key API_KEY]\n",
-      "                        [--data-dir DATA_DIR] [--url URL] [--debug] [-v]\n",
-      "                        {download,query,upload} ...\n",
-      "\n",
-      "This command line program accesses the IMAP SDC APIs to query, download, and\n",
-      "upload data files.\n",
-      "\n",
-      "positional arguments:\n",
-      "  {download,query,upload}\n",
-      "    download            Download a file from the IMAP SDC to the locally\n",
-      "                        configured data directory. Run 'download -h' for more\n",
-      "                        information.\n",
-      "    query               Query the IMAP SDC for files matching the query\n",
-      "                        parameters. The query parameters are optional, but at\n",
-      "                        least one must be provided. Run 'query -h' for more\n",
-      "                        information.\n",
-      "    upload              Upload a file to the IMAP SDC. This must be the full\n",
-      "                        path to the file. E.g. imap/mag/l0/2025/01/imap_mag_l0\n",
-      "                        _raw_20250101_v001.pkts. Run 'upload -h' for more\n",
-      "                        information.\n",
-      "\n",
-      "optional arguments:\n",
-      "  -h, --help            show this help message and exit\n",
-      "  --version             Show programs version number and exit. No other\n",
-      "                        parameters needed.\n",
-      "  --api-key API_KEY     API key to authenticate with the IMAP SDC. This can\n",
-      "                        also be set using the IMAP_API_KEY environment\n",
-      "                        variable. It is only necessary for uploading files.\n",
-      "  --data-dir DATA_DIR   Directory to use for reading and writing IMAP data.\n",
-      "                        The default is a 'data/' folder in the current working\n",
-      "                        directory. This can also be set using the\n",
-      "                        IMAP_DATA_DIR environment variable.\n",
-      "  --url URL             URL of the IMAP SDC API. The default is\n",
-      "                        https://api.dev.imap-mission.com. This can also be set\n",
-      "                        using the IMAP_DATA_ACCESS_URL environment variable.\n",
-      "  --debug               Print lots of debugging statements.\n",
-      "  -v, --verbose         Add verbose output\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Show help documentation\n",
     "!imap-data-access -h"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "763a463b",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "#### Querying"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "13b1eb9f",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "usage: imap-data-access query [-h]\n",
-      "                              [--instrument {codice,glows,hi,hit,idex,lo,mag,swapi,swe,ultra}]\n",
-      "                              [--data-level DATA_LEVEL]\n",
-      "                              [--descriptor DESCRIPTOR]\n",
-      "                              [--start-date START_DATE] [--end-date END_DATE]\n",
-      "                              [--repointing REPOINTING] [--version VERSION]\n",
-      "                              [--extension EXTENSION]\n",
-      "                              [--output-format {table,json}]\n",
-      "                              [--filename FILENAME]\n",
-      "\n",
-      "Query the IMAP SDC for files matching the query parameters. The query\n",
-      "parameters are optional, but at least one must be provided.\n",
-      "\n",
-      "optional arguments:\n",
-      "  -h, --help            show this help message and exit\n",
-      "  --instrument {codice,glows,hi,hit,idex,lo,mag,swapi,swe,ultra}\n",
-      "                        Name of the instrument\n",
-      "  --data-level DATA_LEVEL\n",
-      "                        Data level of the product (l0, l1a, l2, etc.)\n",
-      "  --descriptor DESCRIPTOR\n",
-      "                        Descriptor of the product (raw, burst, etc.)\n",
-      "  --start-date START_DATE\n",
-      "                        Start date for files in YYYYMMDD format\n",
-      "  --end-date END_DATE   End date for a range of file timestamps in YYYYMMDD\n",
-      "                        format\n",
-      "  --repointing REPOINTING\n",
-      "                        Repointing number (int)\n",
-      "  --version VERSION     Version of the product in the format 'v001'. Must have\n",
-      "                        one other parameter to run. Passing 'latest' will\n",
-      "                        return latest version of a file\n",
-      "  --extension EXTENSION\n",
-      "                        File extension (cdf, pkts)\n",
-      "  --output-format {table,json}\n",
-      "                        How to format the output, default is 'table'\n",
-      "  --filename FILENAME   Name of a file to be searched for. For convention\n",
-      "                        standards see https://imap-\n",
-      "                        processing.readthedocs.io/en/latest/development-\n",
-      "                        guide/style-guide/naming-conventions.html#data-\n",
-      "                        product-file-naming-conventions\n"
-     ]
-    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Querying"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Show query help documentation\n",
     "!imap-data-access query -h"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "1de490c4",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found [23] matching files\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n",
-      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v001    | imap_swe_l0_raw_20240510_v001.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v002    | imap_swe_l0_raw_20240510_v002.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v007    | imap_swe_l0_raw_20240510_v007.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v008    | imap_swe_l0_raw_20240510_v008.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v009    | imap_swe_l0_raw_20240510_v009.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v010    | imap_swe_l0_raw_20240510_v010.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v011    | imap_swe_l0_raw_20240510_v011.pkts |\n",
-      "| swe        | l0         | raw        | 20240510   | None       | v012    | imap_swe_l0_raw_20240510_v012.pkts |\n",
-      "| swe        | l0         | raw        | 20241018   | None       | v000    | imap_swe_l0_raw_20241018_v000.pkts |\n",
-      "| swe        | l0         | raw        | 20241122   | None       | v000    | imap_swe_l0_raw_20241122_v000.pkts |\n",
-      "| swe        | l0         | raw        | 20241122   | None       | v001    | imap_swe_l0_raw_20241122_v001.pkts |\n",
-      "| swe        | l0         | raw        | 20241212   | None       | v000    | imap_swe_l0_raw_20241212_v000.pkts |\n",
-      "| swe        | l1a        | sci        | 20240510   | None       | v001    | imap_swe_l1a_sci_20240510_v001.cdf |\n",
-      "| swe        | l1a        | sci        | 20240510   | None       | v002    | imap_swe_l1a_sci_20240510_v002.cdf |\n",
-      "| swe        | l1a        | sci        | 20240510   | None       | v012    | imap_swe_l1a_sci_20240510_v012.cdf |\n",
-      "| swe        | l1a        | sci        | 20250129   | None       | v000    | imap_swe_l1a_sci_20250129_v000.cdf |\n",
-      "| swe        | l1a        | sci        | 20250514   | None       | v000    | imap_swe_l1a_sci_20250514_v000.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v001    | imap_swe_l1b_sci_20240510_v001.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v002    | imap_swe_l1b_sci_20240510_v002.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v003    | imap_swe_l1b_sci_20240510_v003.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
-      "| swe        | l1b        | sci        | 20250129   | None       | v000    | imap_swe_l1b_sci_20250129_v000.cdf |\n",
-      "| swe        | l1b        | sci        | 20250514   | None       | v000    | imap_swe_l1b_sci_20250514_v000.cdf |\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n"
-     ]
-    }
-   ],
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Query with a single parameter\n",
     "!imap-data-access query --instrument swe"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "1553a3f6",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found [4] matching files\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n",
-      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v001    | imap_swe_l1b_sci_20240510_v001.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v002    | imap_swe_l1b_sci_20240510_v002.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v003    | imap_swe_l1b_sci_20240510_v003.cdf |\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n"
-     ]
-    }
-   ],
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Query with multiple parameters\n",
     "!imap-data-access query --instrument swe --data-level l1b --start-date 20240510 --end-date 20240510"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "0cb7f792",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v001.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-10-07 17:06:50'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v002.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v002', 'extension': 'cdf', 'ingestion_date': '2024-10-07 20:07:44'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v003.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v003', 'extension': 'cdf', 'ingestion_date': '2024-11-08 18:26:10'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v012', 'extension': 'cdf', 'ingestion_date': '2024-12-16 22:52:21'}]\n"
-     ]
-    }
-   ],
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Change the output format\n",
     "!imap-data-access query --instrument swe --data-level l1b --start-date 20240510 --end-date 20240510 --output-format json"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "4ebd9c2c-448a-4749-90e3-91124334bc4b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found [1] matching files\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n",
-      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n",
-      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
-      "|---------------------------------------------------------------------------------------------------------------|\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Query based on a filename\n",
     "!imap-data-access query --filename imap_swe_l1b_sci_20240510_v012.cdf"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "bcfdad53",
+   "source": [
+    "#### Downloading"
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   },
-   "source": [
-    "#### Downloading"
-   ]
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "95605dca",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "usage: imap-data-access download [-h] file_path\n",
-      "\n",
-      "Download a file from the IMAP SDC to the locally configured data directory.\n",
-      "\n",
-      "positional arguments:\n",
-      "  file_path   This must be the full path to the file. E.g.\n",
-      "              imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
-      "\n",
-      "optional arguments:\n",
-      "  -h, --help  show this help message and exit\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Show download help documentation\n",
     "!imap-data-access download -h"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d8a3bbb-0758-4aba-aaf7-1e65d6ee7150",
-   "metadata": {},
-   "source": [
-    "##### Science Files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "aff443b9",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n",
-      "-rw-r--r--  1 mabo8927  2260  304761 Feb 18 14:09 /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n"
-     ]
-    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Science Files"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Download a science file\n",
     "!imap-data-access download imap_swe_l1b_sci_20240510_v012.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
     "!ls -lt $IMAP_DATA_DIR/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "04befc41-2e35-486c-a27f-2965f203f2c3",
-   "metadata": {},
-   "source": [
-    "##### Ancillary Files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "600ed5bb-2d69-4d8e-810e-090e764e392a",
+   ],
    "metadata": {
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf\n",
-      "-rw-r--r--  1 mabo8927  2260  3269 Feb 18 14:10 /Users/mabo8927/imap_data/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf\n"
-     ]
-    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "##### Ancillary Files"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "# Download an ancillary file\n",
     "!imap-data-access download imap_mag_calibration_20240229_v001.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
     "!ls -lt $IMAP_DATA_DIR/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "44bf4ae1",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "#### Uploading"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "8d8dc814",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "usage: imap-data-access upload [-h] file_path\n",
-      "\n",
-      "Upload a file to the IMAP SDC. This must be the full path to the file. E.g.\n",
-      "imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts.\n",
-      "\n",
-      "positional arguments:\n",
-      "  file_path   This must be the full path to the file. E.g.\n",
-      "              imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
-      "\n",
-      "optional arguments:\n",
-      "  -h, --help  show this help message and exit\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Show upload help documentation\n",
-    "!imap-data-access upload -h"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "07dc3b32",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found [8] matching files\n",
-      "|------------------------------------------------------------------------------------------------------------------|\n",
-      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                              |\n",
-      "|------------------------------------------------------------------------------------------------------------------|\n",
-      "| codice     | l0         | raw        | 20241122   | None       | v000    | imap_codice_l0_raw_20241122_v000.pkts |\n",
-      "| codice     | l0         | raw        | 20241212   | None       | v000    | imap_codice_l0_raw_20241212_v000.pkts |\n",
-      "| codice     | l0         | raw        | 20250130   | None       | v000    | imap_codice_l0_raw_20250130_v000.pkts |\n",
-      "| codice     | l0         | raw        | 20250218   | None       | v001    | imap_codice_l0_raw_20250218_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250219   | None       | v001    | imap_codice_l0_raw_20250219_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250220   | None       | v001    | imap_codice_l0_raw_20250220_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250221   | None       | v001    | imap_codice_l0_raw_20250221_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20241110   | None       | v001    | imap_codice_l0_raw_20241110_v001.pkts |\n",
-      "|------------------------------------------------------------------------------------------------------------------|\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Show the current CoDICE files to see what is there\n",
-    "!imap-data-access query --instrument codice --data-level l0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "8ac3f473",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Successfully uploaded the file to the IMAP SDC\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Upload the file\n",
-    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_raw_20250222_v001.pkts"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "4d8c2215",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found [9] matching files\n",
-      "|------------------------------------------------------------------------------------------------------------------|\n",
-      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                              |\n",
-      "|------------------------------------------------------------------------------------------------------------------|\n",
-      "| codice     | l0         | raw        | 20241122   | None       | v000    | imap_codice_l0_raw_20241122_v000.pkts |\n",
-      "| codice     | l0         | raw        | 20241212   | None       | v000    | imap_codice_l0_raw_20241212_v000.pkts |\n",
-      "| codice     | l0         | raw        | 20250130   | None       | v000    | imap_codice_l0_raw_20250130_v000.pkts |\n",
-      "| codice     | l0         | raw        | 20250218   | None       | v001    | imap_codice_l0_raw_20250218_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250219   | None       | v001    | imap_codice_l0_raw_20250219_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250220   | None       | v001    | imap_codice_l0_raw_20250220_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250221   | None       | v001    | imap_codice_l0_raw_20250221_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20250222   | None       | v001    | imap_codice_l0_raw_20250222_v001.pkts |\n",
-      "| codice     | l0         | raw        | 20241110   | None       | v001    | imap_codice_l0_raw_20241110_v001.pkts |\n",
-      "|------------------------------------------------------------------------------------------------------------------|\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Check the CoDICE files to see that it was uploaded\n",
-    "!imap-data-access query --instrument codice --data-level l0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44f640d3",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "## Python Package\n",
     "The following section shows examples of how to use the API via the `imap_data_access` Python package."
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "20299694",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "execution_count": null,
    "outputs": [],
    "source": [
     "# import the package\n",
     "import imap_data_access"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7f6610a1",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "The `<IMAP_DATA_DIR>` can be set via the `config` dictionary:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "713656c4",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "The `<IMAP_DATA_DIR>` can be set via the `config` dictionary:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
     "imap_data_access.config[\"DATA_DIR\"] = Path.home() / \"imap_data\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd85b46c",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "#### Querying"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "1ebe63c4",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v001.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-10-07 17:05:14'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v002.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v002', 'extension': 'pkts', 'ingestion_date': '2024-10-07 20:06:01'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v007.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v007', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:31:33'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v008.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v008', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:41:11'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v009.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v009', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:47:41'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v010.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v010', 'extension': 'pkts', 'ingestion_date': '2024-12-09 21:49:09'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v011.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v011', 'extension': 'pkts', 'ingestion_date': '2024-12-11 20:13:33'}\n",
-      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v012.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v012', 'extension': 'pkts', 'ingestion_date': '2024-12-16 22:50:52'}\n",
-      "{'file_path': 'imap/swe/l0/2024/10/imap_swe_l0_raw_20241018_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241018', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-10-28 23:05:10'}\n",
-      "{'file_path': 'imap/swe/l0/2024/11/imap_swe_l0_raw_20241122_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241122', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-12-13 01:40:14'}\n",
-      "{'file_path': 'imap/swe/l0/2024/11/imap_swe_l0_raw_20241122_v001.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241122', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2025-01-29 21:14:01'}\n",
-      "{'file_path': 'imap/swe/l0/2024/12/imap_swe_l0_raw_20241212_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241212', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2025-01-30 19:50:17'}\n"
-     ]
-    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Querying"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "results = imap_data_access.query(instrument=\"swe\", data_level=\"l0\")\n",
     "for result in results:\n",
     "    print(result)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07e38243",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "#### Download a file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "4ede07e0",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%%\n"
     }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/mabo8927/imap_data/imap/swe/l0/2024/12/imap_swe_l0_raw_20241212_v000.pkts\n"
-     ]
-    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Download a file"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "file_path = imap_data_access.download(\"imap_swe_l0_raw_20241212_v000.pkts\")\n",
     "print(file_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0cc4dc50",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "#### Upload a file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "48d97d90",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "imap_data_access.upload(\n",
-    "    f\"{Path.home()}/imap_data/imap_codice_l0_raw_20250223_v001.pkts\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "e88d7885",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{'file_path': 'imap/codice/l0/2025/02/imap_codice_l0_raw_20250223_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250223', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2025-02-18 21:12:45'}]\n"
-     ]
-    }
    ],
-   "source": [
-    "# Check to see if file was uploaded\n",
-    "results = imap_data_access.query(\n",
-    "    instrument=\"codice\", descriptor=\"raw\", start_date=\"20250223\", end_date=\"20250223\"\n",
-    ")\n",
-    "print(results)"
-   ]
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "819ccdd3",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "#### Bonus: validate/construct a file path"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "e9e10981",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "20250502\n",
-      "raw\n",
-      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "science_file = imap_data_access.ScienceFilePath(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
     "print(science_file.start_date)\n",
@@ -1035,52 +454,34 @@
     "\n",
     "filepath = science_file.construct_path()\n",
     "print(filepath)"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "id": "cfee3b10",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "## Future work\n",
     "\n",
     "The SDC continues to develop the API for the greater needs of the IMAP community. We currently have plans to add the following features (subject to change):\n",
     "\n",
-    "- Add support for uploading and querying ancillary files\n",
-    "- Add support for uploading, downloading, and querying SPICE files\n",
+    "- Add support for querying ancillary files\n",
+    "- Add support for querying and downloading SPICE files\n",
     "- Add query parameter for querying based on repointing\n",
     "- Add `today` as a query parameter to return list of files that were acquired in the last 24 hours\n",
     "- Add `days_ago=N` as a query parameter to return a list of file that were acquired in the last `N` days\n",
     "- Create a production instance of the API"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bf4766b9",
+   ],
    "metadata": {
     "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   },
-   "source": [
-    "## Ideas/requests for other API features or endpoints?\n",
-    "\n",
-    "We would like to gather user feedback on how we could improve or expand upon the existing API. What API endpoints could we add? What kind of information would be useful to get from the API?\n",
-    "\n",
-    "For feature requests and bug reports, please open a [new issue](https://github.com/IMAP-Science-Operations-Center/imap-data-access/issues/new) in the Data Access API repository."
-   ]
+   }
   }
  ],
  "metadata": {

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "4bc7ea42",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# IMAP Data Access API\n",
     "\n",
@@ -12,16 +22,20 @@
     "3. Calls to the REST API directly\n",
     "\n",
     "This notebook provies instructions and examples of how to use the command-line utility and python package. *For information on how to use the REST API directly, see https://imap-processing.readthedocs.io/en/latest/data-access/index.html*"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5a5ce072",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Data Directory\n",
     "\n",
@@ -52,401 +66,771 @@
     "```\n",
     "\n",
     "By default, the `<IMAP_DATA_DIR>` is the user's current working directory. However, this can be changed by setting the `IMAP_DATA_DIR` environment variable:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 1,
+   "id": "b661ed52",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: IMAP_DATA_DIR=/Users/mabo8927/imap_data\n",
+      "/Users/mabo8927/imap_data\n"
+     ]
+    }
+   ],
    "source": [
     "!mkdir -p /Users/mabo8927/imap_data/\n",
     "%env IMAP_DATA_DIR=/Users/mabo8927/imap_data\n",
     "!echo $IMAP_DATA_DIR"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5c968496",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Installation\n",
     "\n",
     "The API can be installed via `pip`:"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "!pip install imap-data-access\n",
-    "!imap-data-access --version"
-   ],
+   "execution_count": 2,
+   "id": "0e509f24",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting imap-data-access\n",
+      "  Using cached imap_data_access-0.13.1-py3-none-any.whl\n",
+      "Installing collected packages: imap-data-access\n",
+      "Successfully installed imap-data-access-0.13.1\n",
+      "\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
+      "imap-data-access 0.13.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install imap-data-access\n",
+    "!imap-data-access --version"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "We leave it as an exercise to the user to install the package into their software environment of choice."
-   ],
+   "id": "29cc0413",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "We leave it as an exercise to the user to install the package into their software environment of choice."
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c6425314",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Command Line Utility\n",
     "\n",
     "The following section shows examples of how to use the API via the `imap-data-access` command line utility."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 3,
+   "id": "f834c334",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access [-h] [--version] [--api-key API_KEY]\n",
+      "                        [--data-dir DATA_DIR] [--url URL] [--debug] [-v]\n",
+      "                        {download,query,upload} ...\n",
+      "\n",
+      "This command line program accesses the IMAP SDC APIs to query, download, and\n",
+      "upload data files.\n",
+      "\n",
+      "positional arguments:\n",
+      "  {download,query,upload}\n",
+      "    download            Download a file from the IMAP SDC to the locally\n",
+      "                        configured data directory. Run 'download -h' for more\n",
+      "                        information.\n",
+      "    query               Query the IMAP SDC for files matching the query\n",
+      "                        parameters. The query parameters are optional, but at\n",
+      "                        least one must be provided. Run 'query -h' for more\n",
+      "                        information.\n",
+      "    upload              Upload a file to the IMAP SDC. This must be the full\n",
+      "                        path to the file. E.g. imap/mag/l0/2025/01/imap_mag_l0\n",
+      "                        _raw_20250101_v001.pkts. Run 'upload -h' for more\n",
+      "                        information.\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  --version             Show programs version number and exit. No other\n",
+      "                        parameters needed.\n",
+      "  --api-key API_KEY     API key to authenticate with the IMAP SDC. This can\n",
+      "                        also be set using the IMAP_API_KEY environment\n",
+      "                        variable. It is only necessary for uploading files.\n",
+      "  --data-dir DATA_DIR   Directory to use for reading and writing IMAP data.\n",
+      "                        The default is a 'data/' folder in the current working\n",
+      "                        directory. This can also be set using the\n",
+      "                        IMAP_DATA_DIR environment variable.\n",
+      "  --url URL             URL of the IMAP SDC API. The default is\n",
+      "                        https://api.dev.imap-mission.com. This can also be set\n",
+      "                        using the IMAP_DATA_ACCESS_URL environment variable.\n",
+      "  --debug               Print lots of debugging statements.\n",
+      "  -v, --verbose         Add verbose output\n"
+     ]
+    }
+   ],
    "source": [
     "# Show help documentation\n",
     "!imap-data-access -h"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Querying"
-   ],
+   "id": "79aa3cd7",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### Querying"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 4,
+   "id": "3a16b049",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access query [-h]\n",
+      "                              [--instrument {codice,glows,hi,hit,idex,lo,mag,swapi,swe,ultra}]\n",
+      "                              [--data-level DATA_LEVEL]\n",
+      "                              [--descriptor DESCRIPTOR]\n",
+      "                              [--start-date START_DATE] [--end-date END_DATE]\n",
+      "                              [--repointing REPOINTING] [--version VERSION]\n",
+      "                              [--extension EXTENSION]\n",
+      "                              [--output-format {table,json}]\n",
+      "                              [--filename FILENAME]\n",
+      "\n",
+      "Query the IMAP SDC for files matching the query parameters. The query\n",
+      "parameters are optional, but at least one must be provided.\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  --instrument {codice,glows,hi,hit,idex,lo,mag,swapi,swe,ultra}\n",
+      "                        Name of the instrument\n",
+      "  --data-level DATA_LEVEL\n",
+      "                        Data level of the product (l0, l1a, l2, etc.)\n",
+      "  --descriptor DESCRIPTOR\n",
+      "                        Descriptor of the product (raw, burst, etc.)\n",
+      "  --start-date START_DATE\n",
+      "                        Start date for files in YYYYMMDD format\n",
+      "  --end-date END_DATE   End date for a range of file timestamps in YYYYMMDD\n",
+      "                        format\n",
+      "  --repointing REPOINTING\n",
+      "                        Repointing number (int)\n",
+      "  --version VERSION     Version of the product in the format 'v001'. Must have\n",
+      "                        one other parameter to run. Passing 'latest' will\n",
+      "                        return latest version of a file\n",
+      "  --extension EXTENSION\n",
+      "                        File extension (cdf, pkts)\n",
+      "  --output-format {table,json}\n",
+      "                        How to format the output, default is 'table'\n",
+      "  --filename FILENAME   Name of a file to be searched for. For convention\n",
+      "                        standards see https://imap-\n",
+      "                        processing.readthedocs.io/en/latest/development-\n",
+      "                        guide/style-guide/naming-conventions.html#data-\n",
+      "                        product-file-naming-conventions\n"
+     ]
+    }
+   ],
    "source": [
     "# Show query help documentation\n",
     "!imap-data-access query -h"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 5,
+   "id": "142c8d26",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [23] matching files\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v001    | imap_swe_l0_raw_20240510_v001.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v002    | imap_swe_l0_raw_20240510_v002.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v007    | imap_swe_l0_raw_20240510_v007.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v008    | imap_swe_l0_raw_20240510_v008.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v009    | imap_swe_l0_raw_20240510_v009.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v010    | imap_swe_l0_raw_20240510_v010.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v011    | imap_swe_l0_raw_20240510_v011.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v012    | imap_swe_l0_raw_20240510_v012.pkts |\n",
+      "| swe        | l0         | raw        | 20241018   | None       | v000    | imap_swe_l0_raw_20241018_v000.pkts |\n",
+      "| swe        | l0         | raw        | 20241122   | None       | v000    | imap_swe_l0_raw_20241122_v000.pkts |\n",
+      "| swe        | l0         | raw        | 20241122   | None       | v001    | imap_swe_l0_raw_20241122_v001.pkts |\n",
+      "| swe        | l0         | raw        | 20241212   | None       | v000    | imap_swe_l0_raw_20241212_v000.pkts |\n",
+      "| swe        | l1a        | sci        | 20240510   | None       | v001    | imap_swe_l1a_sci_20240510_v001.cdf |\n",
+      "| swe        | l1a        | sci        | 20240510   | None       | v002    | imap_swe_l1a_sci_20240510_v002.cdf |\n",
+      "| swe        | l1a        | sci        | 20240510   | None       | v012    | imap_swe_l1a_sci_20240510_v012.cdf |\n",
+      "| swe        | l1a        | sci        | 20250129   | None       | v000    | imap_swe_l1a_sci_20250129_v000.cdf |\n",
+      "| swe        | l1a        | sci        | 20250514   | None       | v000    | imap_swe_l1a_sci_20250514_v000.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v001    | imap_swe_l1b_sci_20240510_v001.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v002    | imap_swe_l1b_sci_20240510_v002.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v003    | imap_swe_l1b_sci_20240510_v003.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
+      "| swe        | l1b        | sci        | 20250129   | None       | v000    | imap_swe_l1b_sci_20250129_v000.cdf |\n",
+      "| swe        | l1b        | sci        | 20250514   | None       | v000    | imap_swe_l1b_sci_20250514_v000.cdf |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
    "source": [
     "# Query with a single parameter\n",
     "!imap-data-access query --instrument swe"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 6,
+   "id": "5b4efe84",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [4] matching files\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v001    | imap_swe_l1b_sci_20240510_v001.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v002    | imap_swe_l1b_sci_20240510_v002.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v003    | imap_swe_l1b_sci_20240510_v003.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
    "source": [
     "# Query with multiple parameters\n",
     "!imap-data-access query --instrument swe --data-level l1b --start-date 20240510 --end-date 20240510"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 7,
+   "id": "d7129ee4",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v001.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-10-07 17:06:50'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v002.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v002', 'extension': 'cdf', 'ingestion_date': '2024-10-07 20:07:44'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v003.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v003', 'extension': 'cdf', 'ingestion_date': '2024-11-08 18:26:10'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v012', 'extension': 'cdf', 'ingestion_date': '2024-12-16 22:52:21'}]\n"
+     ]
+    }
+   ],
    "source": [
     "# Change the output format\n",
     "!imap-data-access query --instrument swe --data-level l1b --start-date 20240510 --end-date 20240510 --output-format json"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 8,
+   "id": "5fd49293",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [1] matching files\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
    "source": [
     "# Query based on a filename\n",
     "!imap-data-access query --filename imap_swe_l1b_sci_20240510_v012.cdf"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Downloading"
-   ],
+   "id": "43f58f6c",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### Downloading"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 9,
+   "id": "d7bac45d",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: imap-data-access download [-h] file_path\n",
+      "\n",
+      "Download a file from the IMAP SDC to the locally configured data directory.\n",
+      "\n",
+      "positional arguments:\n",
+      "  file_path   This must be the full path to the file. E.g.\n",
+      "              imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "\n",
+      "optional arguments:\n",
+      "  -h, --help  show this help message and exit\n"
+     ]
+    }
+   ],
    "source": [
     "# Show download help documentation\n",
     "!imap-data-access download -h"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "##### Science Files"
-   ],
+   "id": "2b4b5277",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "##### Science Files"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 10,
+   "id": "cd2952a6",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n",
+      "-rw-r--r--  1 mabo8927  2260  304761 Feb 18 15:12 /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n"
+     ]
+    }
+   ],
    "source": [
     "# Download a science file\n",
     "!imap-data-access download imap_swe_l1b_sci_20240510_v012.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
     "!ls -lt $IMAP_DATA_DIR/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "##### Ancillary Files"
-   ],
+   "id": "bbc95b74",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "##### Ancillary Files"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 11,
+   "id": "8303edf6",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf\n",
+      "-rw-r--r--  1 mabo8927  2260  3269 Feb 18 15:12 /Users/mabo8927/imap_data/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf\n"
+     ]
+    }
+   ],
    "source": [
     "# Download an ancillary file\n",
     "!imap-data-access download imap_mag_calibration_20240229_v001.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
     "!ls -lt $IMAP_DATA_DIR/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Python Package\n",
-    "The following section shows examples of how to use the API via the `imap_data_access` Python package."
-   ],
+   "id": "41b4dfa3",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Python Package\n",
+    "The following section shows examples of how to use the API via the `imap_data_access` Python package."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
+   "id": "88fcc080",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import the package\n",
     "import imap_data_access"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "The `<IMAP_DATA_DIR>` can be set via the `config` dictionary:"
-   ],
+   "id": "069d43fd",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "The `<IMAP_DATA_DIR>` can be set via the `config` dictionary:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
+   "id": "44c98866",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
     "imap_data_access.config[\"DATA_DIR\"] = Path.home() / \"imap_data\""
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Querying"
-   ],
+   "id": "7d2eb208",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### Querying"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 14,
+   "id": "5e1f9262",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v001.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-10-07 17:05:14'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v002.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v002', 'extension': 'pkts', 'ingestion_date': '2024-10-07 20:06:01'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v007.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v007', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:31:33'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v008.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v008', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:41:11'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v009.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v009', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:47:41'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v010.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v010', 'extension': 'pkts', 'ingestion_date': '2024-12-09 21:49:09'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v011.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v011', 'extension': 'pkts', 'ingestion_date': '2024-12-11 20:13:33'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v012.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v012', 'extension': 'pkts', 'ingestion_date': '2024-12-16 22:50:52'}\n",
+      "{'file_path': 'imap/swe/l0/2024/10/imap_swe_l0_raw_20241018_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241018', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-10-28 23:05:10'}\n",
+      "{'file_path': 'imap/swe/l0/2024/11/imap_swe_l0_raw_20241122_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241122', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-12-13 01:40:14'}\n",
+      "{'file_path': 'imap/swe/l0/2024/11/imap_swe_l0_raw_20241122_v001.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241122', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2025-01-29 21:14:01'}\n",
+      "{'file_path': 'imap/swe/l0/2024/12/imap_swe_l0_raw_20241212_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241212', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2025-01-30 19:50:17'}\n"
+     ]
+    }
+   ],
    "source": [
     "results = imap_data_access.query(instrument=\"swe\", data_level=\"l0\")\n",
     "for result in results:\n",
     "    print(result)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Download a file"
-   ],
+   "id": "973646fa",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### Download a file"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 15,
+   "id": "816461a7",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/mabo8927/imap_data/imap/swe/l0/2024/12/imap_swe_l0_raw_20241212_v000.pkts\n"
+     ]
+    }
+   ],
    "source": [
     "file_path = imap_data_access.download(\"imap_swe_l0_raw_20241212_v000.pkts\")\n",
     "print(file_path)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "#### Bonus: validate/construct a file path"
-   ],
+   "id": "2a4ee3b6",
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "#### Bonus: validate/construct a file path"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 16,
+   "id": "cc39d4e1",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20250502\n",
+      "raw\n",
+      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
+     ]
+    }
+   ],
    "source": [
     "science_file = imap_data_access.ScienceFilePath(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
     "print(science_file.start_date)\n",
@@ -454,16 +838,20 @@
     "\n",
     "filepath = science_file.construct_path()\n",
     "print(filepath)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7d19e1b2",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Future work\n",
     "\n",
@@ -475,13 +863,23 @@
     "- Add `today` as a query parameter to return list of files that were acquired in the last 24 hours\n",
     "- Add `days_ago=N` as a query parameter to return a list of file that were acquired in the last `N` days\n",
     "- Create a production instance of the API"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19305296-c95a-4447-ac2f-7d69fc2e13da",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Ideas/requests for other API features or endpoints?\n",
+    "\n",
+    "We would like to gather user feedback on how we could improve or expand upon the existing API. What API endpoints could we add? What kind of information would be useful to get from the API?\n",
+    "\n",
+    "For feature requests and bug reports, please open a [new issue](https://github.com/IMAP-Science-Operations-Center/imap-data-access/issues/new/choose) in the Data Access API repository.\n"
+   ]
   }
  ],
  "metadata": {

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -134,13 +134,13 @@
      "output_type": "stream",
      "text": [
       "Collecting imap-data-access\n",
-      "  Using cached imap_data_access-0.13.0-py3-none-any.whl\n",
+      "  Using cached imap_data_access-0.13.1-py3-none-any.whl\n",
       "Installing collected packages: imap-data-access\n",
-      "Successfully installed imap-data-access-0.13.0\n",
+      "Successfully installed imap-data-access-0.13.1\n",
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "imap-data-access 0.13.0\n"
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m24.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m25.0.1\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
+      "imap-data-access 0.13.1\n"
      ]
     }
    ],
@@ -546,7 +546,7 @@
      "output_type": "stream",
      "text": [
       "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n",
-      "-rw-r--r--  1 mabo8927  2260  304761 Feb 18 11:16 /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n"
+      "-rw-r--r--  1 mabo8927  2260  304761 Feb 18 14:09 /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n"
      ]
     }
    ],
@@ -568,16 +568,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "600ed5bb-2d69-4d8e-810e-090e764e392a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "module 'imap_data_access' has no attribute 'AncillaryFilePath'\n",
-      "ls: /Users/mabo8927/imap_data/imap_mag_calibration_20240229_v001.cdf: No such file or directory\n"
+      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf\n",
+      "-rw-r--r--  1 mabo8927  2260  3269 Feb 18 14:10 /Users/mabo8927/imap_data/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf\n"
      ]
     }
    ],
@@ -586,7 +590,7 @@
     "!imap-data-access download imap_mag_calibration_20240229_v001.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
-    "!ls -lt $IMAP_DATA_DIR/imap_mag_calibration_20240229_v001.cdf"
+    "!ls -lt $IMAP_DATA_DIR/imap/ancillary/mag/imap_mag_calibration_20240229_v001.cdf"
    ]
   },
   {
@@ -607,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "8d8dc814",
    "metadata": {
     "collapsed": false,
@@ -644,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "07dc3b32",
    "metadata": {
     "collapsed": false,
@@ -660,7 +664,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [6] matching files\n",
+      "Found [8] matching files\n",
       "|------------------------------------------------------------------------------------------------------------------|\n",
       "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                              |\n",
       "|------------------------------------------------------------------------------------------------------------------|\n",
@@ -669,6 +673,8 @@
       "| codice     | l0         | raw        | 20250130   | None       | v000    | imap_codice_l0_raw_20250130_v000.pkts |\n",
       "| codice     | l0         | raw        | 20250218   | None       | v001    | imap_codice_l0_raw_20250218_v001.pkts |\n",
       "| codice     | l0         | raw        | 20250219   | None       | v001    | imap_codice_l0_raw_20250219_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250220   | None       | v001    | imap_codice_l0_raw_20250220_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250221   | None       | v001    | imap_codice_l0_raw_20250221_v001.pkts |\n",
       "| codice     | l0         | raw        | 20241110   | None       | v001    | imap_codice_l0_raw_20241110_v001.pkts |\n",
       "|------------------------------------------------------------------------------------------------------------------|\n"
      ]
@@ -681,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "8ac3f473",
    "metadata": {
     "collapsed": false,
@@ -697,18 +703,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/mabo8927/imap_data/imap_codice_l0_raw_20250218_v001.pkts\n"
+      "Successfully uploaded the file to the IMAP SDC\n"
      ]
     }
    ],
    "source": [
     "# Upload the file\n",
-    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_raw_20250218_v001.pkts"
+    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_raw_20250222_v001.pkts"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "4d8c2215",
    "metadata": {
     "collapsed": false,
@@ -724,7 +730,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [6] matching files\n",
+      "Found [9] matching files\n",
       "|------------------------------------------------------------------------------------------------------------------|\n",
       "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                              |\n",
       "|------------------------------------------------------------------------------------------------------------------|\n",
@@ -733,6 +739,9 @@
       "| codice     | l0         | raw        | 20250130   | None       | v000    | imap_codice_l0_raw_20250130_v000.pkts |\n",
       "| codice     | l0         | raw        | 20250218   | None       | v001    | imap_codice_l0_raw_20250218_v001.pkts |\n",
       "| codice     | l0         | raw        | 20250219   | None       | v001    | imap_codice_l0_raw_20250219_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250220   | None       | v001    | imap_codice_l0_raw_20250220_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250221   | None       | v001    | imap_codice_l0_raw_20250221_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250222   | None       | v001    | imap_codice_l0_raw_20250222_v001.pkts |\n",
       "| codice     | l0         | raw        | 20241110   | None       | v001    | imap_codice_l0_raw_20241110_v001.pkts |\n",
       "|------------------------------------------------------------------------------------------------------------------|\n"
      ]
@@ -762,7 +771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "20299694",
    "metadata": {
     "collapsed": false,
@@ -797,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "713656c4",
    "metadata": {
     "collapsed": false,
@@ -833,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "1ebe63c4",
    "metadata": {
     "collapsed": false,
@@ -888,7 +897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "4ede07e0",
    "metadata": {
     "collapsed": false,
@@ -931,41 +940,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "48d97d90",
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "ename": "FileNotFoundError",
-     "evalue": "/Users/mabo8927/imap_data/imap_codice_l0_raw_20250219_v001.pkts",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mimap_data_access\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupload\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;124;43mf\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;132;43;01m{\u001b[39;49;00m\u001b[43mPath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mhome\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;132;43;01m}\u001b[39;49;00m\u001b[38;5;124;43m/imap_data/imap_codice_l0_raw_20250219_v001.pkts\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\n\u001b[1;32m      3\u001b[0m \u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Desktop/envs/poetry/lib/python3.9/site-packages/imap_data_access/io.py:272\u001b[0m, in \u001b[0;36mupload\u001b[0;34m(file_path, api_key)\u001b[0m\n\u001b[1;32m    270\u001b[0m file_path \u001b[38;5;241m=\u001b[39m Path(file_path)\u001b[38;5;241m.\u001b[39mresolve()\n\u001b[1;32m    271\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m file_path\u001b[38;5;241m.\u001b[39mexists():\n\u001b[0;32m--> 272\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m(file_path)\n\u001b[1;32m    274\u001b[0m url \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mimap_data_access\u001b[38;5;241m.\u001b[39mconfig[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mDATA_ACCESS_URL\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    275\u001b[0m \u001b[38;5;66;03m# The upload name needs to be given as a path parameter\u001b[39;00m\n",
-      "\u001b[0;31mFileNotFoundError\u001b[0m: /Users/mabo8927/imap_data/imap_codice_l0_raw_20250219_v001.pkts"
-     ]
-    }
-   ],
-   "source": [
-    "imap_data_access.upload(\n",
-    "    f\"{Path.home()}/imap_data/imap_codice_l0_raw_20250219_v001.pkts\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e88d7885",
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -977,9 +953,37 @@
    },
    "outputs": [],
    "source": [
+    "imap_data_access.upload(\n",
+    "    f\"{Path.home()}/imap_data/imap_codice_l0_raw_20250223_v001.pkts\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "e88d7885",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'file_path': 'imap/codice/l0/2025/02/imap_codice_l0_raw_20250223_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250223', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2025-02-18 21:12:45'}]\n"
+     ]
+    }
+   ],
+   "source": [
     "# Check to see if file was uploaded\n",
     "results = imap_data_access.query(\n",
-    "    instrument=\"codice\", descriptor=\"raw\", start_date=\"20250219\", end_date=\"20250219\"\n",
+    "    instrument=\"codice\", descriptor=\"raw\", start_date=\"20250223\", end_date=\"20250223\"\n",
     ")\n",
     "print(results)"
    ]
@@ -1002,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "e9e10981",
    "metadata": {
     "collapsed": false,
@@ -1013,7 +1017,17 @@
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20250502\n",
+      "raw\n",
+      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
+     ]
+    }
+   ],
    "source": [
     "science_file = imap_data_access.ScienceFilePath(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
     "print(science_file.start_date)\n",

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -860,8 +860,6 @@
     "- Add support for querying ancillary files\n",
     "- Add support for querying and downloading SPICE files\n",
     "- Add query parameter for querying based on repointing\n",
-    "- Add `today` as a query parameter to return list of files that were acquired in the last 24 hours\n",
-    "- Add `days_ago=N` as a query parameter to return a list of file that were acquired in the last `N` days\n",
     "- Create a production instance of the API"
    ]
   },

--- a/examples/api_demo.ipynb
+++ b/examples/api_demo.ipynb
@@ -2,8 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "dd5f888d-8589-4385-ac6e-19899bc4f1e2",
-   "metadata": {},
+   "id": "f28c0487",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# IMAP Data Access API\n",
     "\n",
@@ -13,13 +21,21 @@
     "2. The `imap_data_access` python package\n",
     "3. Calls to the REST API directly\n",
     "\n",
-    "This notebook provies instructions and examples of how to use the command-line utility and python package. *For information on how to use the REST API directly, see https://imap-processing.readthedocs.io/en/latest/data-access-api/index.html.*"
+    "This notebook provies instructions and examples of how to use the command-line utility and python package. *For information on how to use the REST API directly, see https://imap-processing.readthedocs.io/en/latest/data-access/index.html*"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "91a25008-383e-4955-a488-505d2979aa69",
-   "metadata": {},
+   "id": "454b8b53",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Data Directory\n",
     "\n",
@@ -55,8 +71,16 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "81113947-cb51-43b8-9a4e-22b68190bf45",
-   "metadata": {},
+   "id": "34486463",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -75,8 +99,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb3324a4-6a31-44d3-9e10-d353dbee74e7",
-   "metadata": {},
+   "id": "5dc33983",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Installation\n",
     "\n",
@@ -86,18 +118,29 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "fb1b82d5-73d3-437e-b25d-c519c6ea1f7a",
-   "metadata": {},
+   "id": "2e21f9fa",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Collecting imap-data-access\n",
-      "  Using cached imap_data_access-0.7.0-py3-none-any.whl\n",
+      "  Using cached imap_data_access-0.13.0-py3-none-any.whl\n",
       "Installing collected packages: imap-data-access\n",
-      "Successfully installed imap-data-access-0.7.0\n",
-      "imap-data-access 0.7.0\n"
+      "Successfully installed imap-data-access-0.13.0\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.0.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "imap-data-access 0.13.0\n"
      ]
     }
    ],
@@ -108,16 +151,32 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee751d1f-4958-42ef-8449-9eb60a9bc1e0",
-   "metadata": {},
+   "id": "3cd2051d",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We leave it as an exercise to the user to install the package into their software environment of choice."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "41582a62-1ecc-4a66-b939-23671821d28b",
-   "metadata": {},
+   "id": "a354d555",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Command Line Utility\n",
     "\n",
@@ -127,8 +186,16 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "22def29d-9d87-4b18-897e-e28147d67091",
-   "metadata": {},
+   "id": "b557418d",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -144,17 +211,21 @@
       "positional arguments:\n",
       "  {download,query,upload}\n",
       "    download            Download a file from the IMAP SDC to the locally\n",
-      "                        configured data directory.\n",
+      "                        configured data directory. Run 'download -h' for more\n",
+      "                        information.\n",
       "    query               Query the IMAP SDC for files matching the query\n",
       "                        parameters. The query parameters are optional, but at\n",
-      "                        least one must be provided.\n",
+      "                        least one must be provided. Run 'query -h' for more\n",
+      "                        information.\n",
       "    upload              Upload a file to the IMAP SDC. This must be the full\n",
-      "                        path to the file. E.g.\n",
-      "                        imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "                        path to the file. E.g. imap/mag/l0/2025/01/imap_mag_l0\n",
+      "                        _raw_20250101_v001.pkts. Run 'upload -h' for more\n",
+      "                        information.\n",
       "\n",
       "optional arguments:\n",
       "  -h, --help            show this help message and exit\n",
-      "  --version             show program's version number and exit\n",
+      "  --version             Show programs version number and exit. No other\n",
+      "                        parameters needed.\n",
       "  --api-key API_KEY     API key to authenticate with the IMAP SDC. This can\n",
       "                        also be set using the IMAP_API_KEY environment\n",
       "                        variable. It is only necessary for uploading files.\n",
@@ -165,7 +236,7 @@
       "  --url URL             URL of the IMAP SDC API. The default is\n",
       "                        https://api.dev.imap-mission.com. This can also be set\n",
       "                        using the IMAP_DATA_ACCESS_URL environment variable.\n",
-      "  --debug               Print lots of debugging statements\n",
+      "  --debug               Print lots of debugging statements.\n",
       "  -v, --verbose         Add verbose output\n"
      ]
     }
@@ -177,8 +248,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26e268c9-4366-4835-8783-0c6c362ab918",
-   "metadata": {},
+   "id": "763a463b",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Querying"
    ]
@@ -186,8 +265,16 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "74ffae35-e2c8-4bf4-9b90-34c225c057e0",
-   "metadata": {},
+   "id": "13b1eb9f",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -201,6 +288,7 @@
       "                              [--repointing REPOINTING] [--version VERSION]\n",
       "                              [--extension EXTENSION]\n",
       "                              [--output-format {table,json}]\n",
+      "                              [--filename FILENAME]\n",
       "\n",
       "Query the IMAP SDC for files matching the query parameters. The query\n",
       "parameters are optional, but at least one must be provided.\n",
@@ -214,15 +302,23 @@
       "  --descriptor DESCRIPTOR\n",
       "                        Descriptor of the product (raw, burst, etc.)\n",
       "  --start-date START_DATE\n",
-      "                        Start date in YYYYMMDD format\n",
-      "  --end-date END_DATE   End date in YYYYMMDD format\n",
+      "                        Start date for files in YYYYMMDD format\n",
+      "  --end-date END_DATE   End date for a range of file timestamps in YYYYMMDD\n",
+      "                        format\n",
       "  --repointing REPOINTING\n",
       "                        Repointing number (int)\n",
-      "  --version VERSION     Version of the product in the format 'v001'\n",
+      "  --version VERSION     Version of the product in the format 'v001'. Must have\n",
+      "                        one other parameter to run. Passing 'latest' will\n",
+      "                        return latest version of a file\n",
       "  --extension EXTENSION\n",
       "                        File extension (cdf, pkts)\n",
       "  --output-format {table,json}\n",
-      "                        How to format the output, default is 'table'\n"
+      "                        How to format the output, default is 'table'\n",
+      "  --filename FILENAME   Name of a file to be searched for. For convention\n",
+      "                        standards see https://imap-\n",
+      "                        processing.readthedocs.io/en/latest/development-\n",
+      "                        guide/style-guide/naming-conventions.html#data-\n",
+      "                        product-file-naming-conventions\n"
      ]
     }
    ],
@@ -234,90 +330,172 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "b9abeb02-f930-4461-956f-1d3e93092332",
-   "metadata": {},
+   "id": "1de490c4",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [7] matching files\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "glows     |l0        |raw       |20110921  |          |v001   |imap_glows_l0_raw_20110921_v001.pkts              |\n",
-      "glows     |l1a       |de        |20110920  |          |v001   |imap_glows_l1a_de_20110920_v001.cdf               |\n",
-      "glows     |l1a       |hist      |20110920  |          |v001   |imap_glows_l1a_hist_20110920_v001.cdf             |\n",
-      "glows     |l1a       |hist      |20110921  |          |v001   |imap_glows_l1a_hist_20110921_v001.cdf             |\n",
-      "glows     |l1b       |de        |20110920  |          |v001   |imap_glows_l1b_de_20110920_v001.cdf               |\n",
-      "glows     |l1b       |hist      |20110920  |          |v001   |imap_glows_l1b_hist_20110920_v001.cdf             |\n",
-      "glows     |l1b       |hist      |20110921  |          |v001   |imap_glows_l1b_hist_20110921_v001.cdf             |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n"
+      "Found [23] matching files\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v001    | imap_swe_l0_raw_20240510_v001.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v002    | imap_swe_l0_raw_20240510_v002.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v007    | imap_swe_l0_raw_20240510_v007.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v008    | imap_swe_l0_raw_20240510_v008.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v009    | imap_swe_l0_raw_20240510_v009.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v010    | imap_swe_l0_raw_20240510_v010.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v011    | imap_swe_l0_raw_20240510_v011.pkts |\n",
+      "| swe        | l0         | raw        | 20240510   | None       | v012    | imap_swe_l0_raw_20240510_v012.pkts |\n",
+      "| swe        | l0         | raw        | 20241018   | None       | v000    | imap_swe_l0_raw_20241018_v000.pkts |\n",
+      "| swe        | l0         | raw        | 20241122   | None       | v000    | imap_swe_l0_raw_20241122_v000.pkts |\n",
+      "| swe        | l0         | raw        | 20241122   | None       | v001    | imap_swe_l0_raw_20241122_v001.pkts |\n",
+      "| swe        | l0         | raw        | 20241212   | None       | v000    | imap_swe_l0_raw_20241212_v000.pkts |\n",
+      "| swe        | l1a        | sci        | 20240510   | None       | v001    | imap_swe_l1a_sci_20240510_v001.cdf |\n",
+      "| swe        | l1a        | sci        | 20240510   | None       | v002    | imap_swe_l1a_sci_20240510_v002.cdf |\n",
+      "| swe        | l1a        | sci        | 20240510   | None       | v012    | imap_swe_l1a_sci_20240510_v012.cdf |\n",
+      "| swe        | l1a        | sci        | 20250129   | None       | v000    | imap_swe_l1a_sci_20250129_v000.cdf |\n",
+      "| swe        | l1a        | sci        | 20250514   | None       | v000    | imap_swe_l1a_sci_20250514_v000.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v001    | imap_swe_l1b_sci_20240510_v001.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v002    | imap_swe_l1b_sci_20240510_v002.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v003    | imap_swe_l1b_sci_20240510_v003.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
+      "| swe        | l1b        | sci        | 20250129   | None       | v000    | imap_swe_l1b_sci_20250129_v000.cdf |\n",
+      "| swe        | l1b        | sci        | 20250514   | None       | v000    | imap_swe_l1b_sci_20250514_v000.cdf |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n"
      ]
     }
    ],
    "source": [
     "# Query with a single parameter\n",
-    "!imap-data-access query --instrument glows"
+    "!imap-data-access query --instrument swe"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a4c487a5-9126-443c-9a99-f871f8315fc1",
-   "metadata": {},
+   "id": "1553a3f6",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [2] matching files\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "glows     |l1a       |hist      |20110920  |          |v001   |imap_glows_l1a_hist_20110920_v001.cdf             |\n",
-      "glows     |l1a       |hist      |20110921  |          |v001   |imap_glows_l1a_hist_20110921_v001.cdf             |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n"
+      "Found [4] matching files\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v001    | imap_swe_l1b_sci_20240510_v001.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v002    | imap_swe_l1b_sci_20240510_v002.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v003    | imap_swe_l1b_sci_20240510_v003.cdf |\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n"
      ]
     }
    ],
    "source": [
     "# Query with multiple parameters\n",
-    "!imap-data-access query --instrument glows --data-level l1a --descriptor hist"
+    "!imap-data-access query --instrument swe --data-level l1b --start-date 20240510 --end-date 20240510"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "114cc8ea-634c-46d8-a350-b71d1ebd5588",
+   "id": "0cb7f792",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v001.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-10-07 17:06:50'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v002.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v002', 'extension': 'cdf', 'ingestion_date': '2024-10-07 20:07:44'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v003.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v003', 'extension': 'cdf', 'ingestion_date': '2024-11-08 18:26:10'}, {'file_path': 'imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf', 'instrument': 'swe', 'data_level': 'l1b', 'descriptor': 'sci', 'start_date': '20240510', 'repointing': None, 'version': 'v012', 'extension': 'cdf', 'ingestion_date': '2024-12-16 22:52:21'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Change the output format\n",
+    "!imap-data-access query --instrument swe --data-level l1b --start-date 20240510 --end-date 20240510 --output-format json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4ebd9c2c-448a-4749-90e3-91124334bc4b",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'file_path': 'imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110920_v001.cdf', 'instrument': 'glows', 'data_level': 'l1a', 'descriptor': 'hist', 'start_date': '20110920', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-07-09 15:42:23'}, {'file_path': 'imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf', 'instrument': 'glows', 'data_level': 'l1a', 'descriptor': 'hist', 'start_date': '20110921', 'repointing': None, 'version': 'v001', 'extension': 'cdf', 'ingestion_date': '2024-07-09 15:42:24'}]\n"
+      "Found [1] matching files\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                           |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n",
+      "| swe        | l1b        | sci        | 20240510   | None       | v012    | imap_swe_l1b_sci_20240510_v012.cdf |\n",
+      "|---------------------------------------------------------------------------------------------------------------|\n"
      ]
     }
    ],
    "source": [
-    "# Change the output format\n",
-    "!imap-data-access query --instrument glows --data-level l1a --descriptor hist --output-format json"
+    "# Query based on a filename\n",
+    "!imap-data-access query --filename imap_swe_l1b_sci_20240510_v012.cdf"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8616a4cf-30bc-4f9f-a8f1-a3393a5c8448",
-   "metadata": {},
+   "id": "bcfdad53",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
-    "#### Download a file"
+    "#### Downloading"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "514544ff-538f-4d63-9965-7400b1e8fc9f",
-   "metadata": {},
+   "execution_count": 9,
+   "id": "95605dca",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -342,41 +520,104 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6d8a3bbb-0758-4aba-aaf7-1e65d6ee7150",
+   "metadata": {},
+   "source": [
+    "##### Science Files"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "c34122dd-9151-4722-93cc-3933d7b55aca",
+   "execution_count": 10,
+   "id": "aff443b9",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n",
+      "-rw-r--r--  1 mabo8927  2260  304761 Feb 18 11:16 /Users/mabo8927/imap_data/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download a science file\n",
+    "!imap-data-access download imap_swe_l1b_sci_20240510_v012.cdf\n",
+    "\n",
+    "# Check to see that the file exists\n",
+    "!ls -lt $IMAP_DATA_DIR/imap/swe/l1b/2024/05/imap_swe_l1b_sci_20240510_v012.cdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04befc41-2e35-486c-a27f-2965f203f2c3",
+   "metadata": {},
+   "source": [
+    "##### Ancillary Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "600ed5bb-2d69-4d8e-810e-090e764e392a",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Successfully downloaded the file to: /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf\n",
-      "-rw-r--r--  1 mabo8927  2260  8183501 Jul 31 16:43 /Users/mabo8927/imap_data/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf\n"
+      "module 'imap_data_access' has no attribute 'AncillaryFilePath'\n",
+      "ls: /Users/mabo8927/imap_data/imap_mag_calibration_20240229_v001.cdf: No such file or directory\n"
      ]
     }
    ],
    "source": [
-    "# Download a file\n",
-    "!imap-data-access download imap_glows_l1a_hist_20110921_v001.cdf\n",
+    "# Download an ancillary file\n",
+    "!imap-data-access download imap_mag_calibration_20240229_v001.cdf\n",
     "\n",
     "# Check to see that the file exists\n",
-    "!ls -lt $IMAP_DATA_DIR/imap/glows/l1a/2011/09/imap_glows_l1a_hist_20110921_v001.cdf"
+    "!ls -lt $IMAP_DATA_DIR/imap_mag_calibration_20240229_v001.cdf"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e4323aba-87c7-4f54-8fe8-c760a130193e",
-   "metadata": {},
+   "id": "44bf4ae1",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
-    "#### Upload a file"
+    "#### Uploading"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "94aa436a-aaad-4e33-b7c8-eb4aa95a84b3",
-   "metadata": {},
+   "execution_count": 12,
+   "id": "8d8dc814",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -385,7 +626,7 @@
       "usage: imap-data-access upload [-h] file_path\n",
       "\n",
       "Upload a file to the IMAP SDC. This must be the full path to the file. E.g.\n",
-      "imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts\n",
+      "imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts.\n",
       "\n",
       "positional arguments:\n",
       "  file_path   This must be the full path to the file. E.g.\n",
@@ -403,124 +644,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "4a4ad566-a418-4a88-a4d7-9bc51f622fc6",
-   "metadata": {},
+   "execution_count": 13,
+   "id": "07dc3b32",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found [12] matching files\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "codice    |l0        |hskp      |20240610  |          |v001   |imap_codice_l0_hskp_20240610_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240610  |          |v100   |imap_codice_l0_hskp_20240610_v100.pkts            |\n",
-      "codice    |l0        |hskp      |20240610  |          |v200   |imap_codice_l0_hskp_20240610_v200.pkts            |\n",
-      "codice    |l0        |hskp      |20240610  |          |v210   |imap_codice_l0_hskp_20240610_v210.pkts            |\n",
-      "codice    |l0        |hskp      |20240720  |          |v001   |imap_codice_l0_hskp_20240720_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240721  |          |v001   |imap_codice_l0_hskp_20240721_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240722  |          |v001   |imap_codice_l0_hskp_20240722_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240723  |          |v001   |imap_codice_l0_hskp_20240723_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240724  |          |v001   |imap_codice_l0_hskp_20240724_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n"
+      "Found [6] matching files\n",
+      "|------------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                              |\n",
+      "|------------------------------------------------------------------------------------------------------------------|\n",
+      "| codice     | l0         | raw        | 20241122   | None       | v000    | imap_codice_l0_raw_20241122_v000.pkts |\n",
+      "| codice     | l0         | raw        | 20241212   | None       | v000    | imap_codice_l0_raw_20241212_v000.pkts |\n",
+      "| codice     | l0         | raw        | 20250130   | None       | v000    | imap_codice_l0_raw_20250130_v000.pkts |\n",
+      "| codice     | l0         | raw        | 20250218   | None       | v001    | imap_codice_l0_raw_20250218_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250219   | None       | v001    | imap_codice_l0_raw_20250219_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20241110   | None       | v001    | imap_codice_l0_raw_20241110_v001.pkts |\n",
+      "|------------------------------------------------------------------------------------------------------------------|\n"
      ]
     }
    ],
    "source": [
     "# Show the current CoDICE files to see what is there\n",
-    "!imap-data-access query --instrument codice --descriptor hskp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "b6e80ccd-3555-4deb-be18-32767a076613",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Successfully uploaded the file to the IMAP SDC\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Upload the file\n",
-    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_hskp_20240725_v001.pkts"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "d923b744-066f-4538-bf91-3a20f96aa88a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found [13] matching files\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "Instrument|Data Level|Descriptor|Start Date|Repointing|Version|Filename                                          |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n",
-      "codice    |l0        |hskp      |20240610  |          |v001   |imap_codice_l0_hskp_20240610_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240610  |          |v100   |imap_codice_l0_hskp_20240610_v100.pkts            |\n",
-      "codice    |l0        |hskp      |20240610  |          |v200   |imap_codice_l0_hskp_20240610_v200.pkts            |\n",
-      "codice    |l0        |hskp      |20240610  |          |v210   |imap_codice_l0_hskp_20240610_v210.pkts            |\n",
-      "codice    |l0        |hskp      |20240720  |          |v001   |imap_codice_l0_hskp_20240720_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240721  |          |v001   |imap_codice_l0_hskp_20240721_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240722  |          |v001   |imap_codice_l0_hskp_20240722_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240723  |          |v001   |imap_codice_l0_hskp_20240723_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240724  |          |v001   |imap_codice_l0_hskp_20240724_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240725  |          |v001   |imap_codice_l0_hskp_20240725_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240729  |          |v001   |imap_codice_l0_hskp_20240729_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20240730  |          |v001   |imap_codice_l0_hskp_20240730_v001.pkts            |\n",
-      "codice    |l0        |hskp      |20250610  |          |v210   |imap_codice_l0_hskp_20250610_v210.pkts            |\n",
-      "-----------------------------------------------------------------------------------------------------------------|\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Check the CoDICE files to see that it was uploaded\n",
-    "!imap-data-access query --instrument codice --descriptor hskp"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b1d2937f-95d2-4b05-bf9a-12010a28ac6d",
-   "metadata": {},
-   "source": [
-    "#### Bonus: Let's see it in action in AWS"
+    "!imap-data-access query --instrument codice --data-level l0"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "b3b89956-b7d8-46f6-8b91-ebff19fe7693",
-   "metadata": {},
+   "id": "8ac3f473",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Successfully uploaded the file to the IMAP SDC\n"
+      "/Users/mabo8927/imap_data/imap_codice_l0_raw_20250218_v001.pkts\n"
      ]
     }
    ],
    "source": [
-    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_lo-counters-singles_20240429_v001.pkts"
+    "# Upload the file\n",
+    "!imap-data-access upload $IMAP_DATA_DIR/imap_codice_l0_raw_20250218_v001.pkts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4d8c2215",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found [6] matching files\n",
+      "|------------------------------------------------------------------------------------------------------------------|\n",
+      "| Instrument | Data Level | Descriptor | Start Date | Repointing | Version | Filename                              |\n",
+      "|------------------------------------------------------------------------------------------------------------------|\n",
+      "| codice     | l0         | raw        | 20241122   | None       | v000    | imap_codice_l0_raw_20241122_v000.pkts |\n",
+      "| codice     | l0         | raw        | 20241212   | None       | v000    | imap_codice_l0_raw_20241212_v000.pkts |\n",
+      "| codice     | l0         | raw        | 20250130   | None       | v000    | imap_codice_l0_raw_20250130_v000.pkts |\n",
+      "| codice     | l0         | raw        | 20250218   | None       | v001    | imap_codice_l0_raw_20250218_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20250219   | None       | v001    | imap_codice_l0_raw_20250219_v001.pkts |\n",
+      "| codice     | l0         | raw        | 20241110   | None       | v001    | imap_codice_l0_raw_20241110_v001.pkts |\n",
+      "|------------------------------------------------------------------------------------------------------------------|\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check the CoDICE files to see that it was uploaded\n",
+    "!imap-data-access query --instrument codice --data-level l0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9226db66-da23-449d-aec9-ee0cf30e8742",
-   "metadata": {},
+   "id": "44f640d3",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Python Package\n",
     "The following section shows examples of how to use the API via the `imap_data_access` Python package."
@@ -528,9 +762,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "b4548bc2-591e-480c-bcc0-6e7b8206a928",
-   "metadata": {},
+   "execution_count": 16,
+   "id": "20299694",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import the package\n",
@@ -539,17 +781,33 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd4a0ad5-eb19-493c-af42-a78abea029c5",
-   "metadata": {},
+   "id": "7f6610a1",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The `<IMAP_DATA_DIR>` can be set via the `config` dictionary:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "d4a7cf75-ac18-4dea-9761-bc9a6824b2d0",
-   "metadata": {},
+   "execution_count": 17,
+   "id": "713656c4",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -559,128 +817,203 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2480140-9f8f-4634-ac35-b7a59c91f42a",
-   "metadata": {},
+   "id": "cd85b46c",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Querying"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "0bb7a88f-c6a9-40aa-adc0-a275505a75c6",
-   "metadata": {},
+   "execution_count": 18,
+   "id": "1ebe63c4",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v000.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250502', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-07-16 10:27:13'}\n",
-      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250502', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-16 10:29:33'}\n",
-      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250511_v000.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250511', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-07-19 16:34:35'}\n",
-      "{'file_path': 'imap/mag/l0/2025/05/imap_mag_l0_raw_20250511_v001.pkts', 'instrument': 'mag', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20250511', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-07-19 16:36:32'}\n"
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v001.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-10-07 17:05:14'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v002.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v002', 'extension': 'pkts', 'ingestion_date': '2024-10-07 20:06:01'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v007.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v007', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:31:33'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v008.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v008', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:41:11'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v009.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v009', 'extension': 'pkts', 'ingestion_date': '2024-12-06 18:47:41'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v010.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v010', 'extension': 'pkts', 'ingestion_date': '2024-12-09 21:49:09'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v011.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v011', 'extension': 'pkts', 'ingestion_date': '2024-12-11 20:13:33'}\n",
+      "{'file_path': 'imap/swe/l0/2024/05/imap_swe_l0_raw_20240510_v012.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20240510', 'repointing': None, 'version': 'v012', 'extension': 'pkts', 'ingestion_date': '2024-12-16 22:50:52'}\n",
+      "{'file_path': 'imap/swe/l0/2024/10/imap_swe_l0_raw_20241018_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241018', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-10-28 23:05:10'}\n",
+      "{'file_path': 'imap/swe/l0/2024/11/imap_swe_l0_raw_20241122_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241122', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2024-12-13 01:40:14'}\n",
+      "{'file_path': 'imap/swe/l0/2024/11/imap_swe_l0_raw_20241122_v001.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241122', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2025-01-29 21:14:01'}\n",
+      "{'file_path': 'imap/swe/l0/2024/12/imap_swe_l0_raw_20241212_v000.pkts', 'instrument': 'swe', 'data_level': 'l0', 'descriptor': 'raw', 'start_date': '20241212', 'repointing': None, 'version': 'v000', 'extension': 'pkts', 'ingestion_date': '2025-01-30 19:50:17'}\n"
      ]
     }
    ],
    "source": [
-    "results = imap_data_access.query(instrument=\"mag\", data_level=\"l0\")\n",
+    "results = imap_data_access.query(instrument=\"swe\", data_level=\"l0\")\n",
     "for result in results:\n",
     "    print(result)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "05e57918-b537-4bdd-891c-62af73c0f251",
-   "metadata": {},
+   "id": "07e38243",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Download a file"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "05668477-e308-4762-8e7b-77b8a6475eda",
-   "metadata": {},
+   "execution_count": 19,
+   "id": "4ede07e0",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
+      "/Users/mabo8927/imap_data/imap/swe/l0/2024/12/imap_swe_l0_raw_20241212_v000.pkts\n"
      ]
     }
    ],
    "source": [
-    "file_path = imap_data_access.download(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
+    "file_path = imap_data_access.download(\"imap_swe_l0_raw_20241212_v000.pkts\")\n",
     "print(file_path)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "53583575-ff2d-4e03-884c-9e4ccd571691",
-   "metadata": {},
+   "id": "0cc4dc50",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Upload a file"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "826101e2-ef0e-4ddb-8431-b6d2999a0721",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 20,
+   "id": "48d97d90",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "/Users/mabo8927/imap_data/imap_codice_l0_raw_20250219_v001.pkts",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mimap_data_access\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupload\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      2\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;124;43mf\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;132;43;01m{\u001b[39;49;00m\u001b[43mPath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mhome\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;132;43;01m}\u001b[39;49;00m\u001b[38;5;124;43m/imap_data/imap_codice_l0_raw_20250219_v001.pkts\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\n\u001b[1;32m      3\u001b[0m \u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Desktop/envs/poetry/lib/python3.9/site-packages/imap_data_access/io.py:272\u001b[0m, in \u001b[0;36mupload\u001b[0;34m(file_path, api_key)\u001b[0m\n\u001b[1;32m    270\u001b[0m file_path \u001b[38;5;241m=\u001b[39m Path(file_path)\u001b[38;5;241m.\u001b[39mresolve()\n\u001b[1;32m    271\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m file_path\u001b[38;5;241m.\u001b[39mexists():\n\u001b[0;32m--> 272\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mFileNotFoundError\u001b[39;00m(file_path)\n\u001b[1;32m    274\u001b[0m url \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mimap_data_access\u001b[38;5;241m.\u001b[39mconfig[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mDATA_ACCESS_URL\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    275\u001b[0m \u001b[38;5;66;03m# The upload name needs to be given as a path parameter\u001b[39;00m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: /Users/mabo8927/imap_data/imap_codice_l0_raw_20250219_v001.pkts"
+     ]
+    }
+   ],
    "source": [
     "imap_data_access.upload(\n",
-    "    f\"{Path.home()}/imap_data/imap_codice_l0_hskp_20240726_v001.pkts\"\n",
+    "    f\"{Path.home()}/imap_data/imap_codice_l0_raw_20250219_v001.pkts\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "2143b551-dc1c-4d3f-ac8b-01f28e7ec1d5",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{'file_path': 'imap/codice/l0/2024/07/imap_codice_l0_hskp_20240726_v001.pkts', 'instrument': 'codice', 'data_level': 'l0', 'descriptor': 'hskp', 'start_date': '20240726', 'repointing': None, 'version': 'v001', 'extension': 'pkts', 'ingestion_date': '2024-08-01 22:27:27'}]\n"
-     ]
+   "execution_count": null,
+   "id": "e88d7885",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "# Check to see if file was uploaded\n",
     "results = imap_data_access.query(\n",
-    "    instrument=\"codice\", descriptor=\"hskp\", start_date=\"20240726\", end_date=\"20240727\"\n",
+    "    instrument=\"codice\", descriptor=\"raw\", start_date=\"20250219\", end_date=\"20250219\"\n",
     ")\n",
     "print(results)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4afad809-a537-4227-ba1c-f8dadd4a456d",
-   "metadata": {},
+   "id": "819ccdd3",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Bonus: validate/construct a file path"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "5615873a-22f1-4921-8e06-bb9db1173f62",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "20250502\n",
-      "raw\n",
-      "/Users/mabo8927/imap_data/imap/mag/l0/2025/05/imap_mag_l0_raw_20250502_v001.pkts\n"
-     ]
+   "execution_count": null,
+   "id": "e9e10981",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "science_file = imap_data_access.ScienceFilePath(\"imap_mag_l0_raw_20250502_v001.pkts\")\n",
     "print(science_file.start_date)\n",
@@ -692,23 +1025,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb21e6a3-fa17-4be0-a3c7-6ae998e701c1",
-   "metadata": {},
+   "id": "cfee3b10",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Future work\n",
     "\n",
     "The SDC continues to develop the API for the greater needs of the IMAP community. We currently have plans to add the following features (subject to change):\n",
     "\n",
-    "- Add `filename` as a query parameter to return information for a particular file\n",
+    "- Add support for uploading and querying ancillary files\n",
+    "- Add support for uploading, downloading, and querying SPICE files\n",
+    "- Add query parameter for querying based on repointing\n",
     "- Add `today` as a query parameter to return list of files that were acquired in the last 24 hours\n",
     "- Add `days_ago=N` as a query parameter to return a list of file that were acquired in the last `N` days\n",
-    "- Add ability to upload ancillary files"
+    "- Create a production instance of the API"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "62b4dffe-ca0e-493a-b57d-428ab211c064",
-   "metadata": {},
+   "id": "bf4766b9",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Ideas/requests for other API features or endpoints?\n",
     "\n",


### PR DESCRIPTION
This PR updates the `examples/api_demo.ipynb` notebook to showcase the latest version of `imap-data-access` and its latest capabilities; namely adding an example of querying with the `--filename` parameters, and downloading ancillary files.

For reviewers: Unfortunately it is not easy to compare changes in Jupyter notebooks on GitHub. I would suggest taking a look [here](https://github.com/bourque/imap-data-access/blob/api_demo_notebook_updates_feb_2025_STM/examples/api_demo.ipynb) to see what the end product looks like.

Closes #121 