### PR TITLE
MNT: fixing file path list to have download path

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from imap_data_access.file_validation import (
     AncillaryFilePath,
+    ImapFilePath,
     ScienceFilePath,
     SPICEFilePath,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "query",
     "download",
     "upload",
+    "ImapFilePath",
     "ScienceFilePath",
     "SPICEFilePath",
     "AncillaryFilePath",

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -58,7 +58,7 @@ class ProcessingInput(ABC):
     # List of filenames
     filename_list: list[str] = None
     # List of download paths
-    file_path_list: list[Path] = None
+    file_obj_list: list[AncillaryFilePath, ScienceFilePath, SPICEFilePath] = None
     input_type: ProcessingInputType = None
     # Following three are retrieved from dependency check.
     # But they can also come from the filename.
@@ -110,13 +110,13 @@ class ProcessingInput(ABC):
         This method is called by the constructor and can be overridden by subclasses.
         It works for ScienceFilePaths and AncillaryFilePaths, but not SPICEFilePaths.
 
-        This sets source, datatype, descriptor, and file_path_list attributes.
+        This sets source, datatype, descriptor, and file_obj_list attributes.
         """
         # For science and ancillary files
         source = set()
         data_type = set()
         descriptor = set()
-        file_path_list = []
+        file_obj_list = []
         for file in self.filename_list:
             path_validator = InputTypePathMapper[self.input_type.name].value(file)
 
@@ -126,8 +126,7 @@ class ProcessingInput(ABC):
             else:
                 data_type.add(self.input_type.value)
             descriptor.add(path_validator.descriptor)
-            # Store download path. This gets used in `imap_processing` cli
-            file_path_list.append(path_validator.construct_path())
+            file_obj_list.append(path_validator)
 
         if len(source) != 1 or len(data_type) != 1 or len(descriptor) != 1:
             raise ValueError(
@@ -137,7 +136,7 @@ class ProcessingInput(ABC):
         self.source = source.pop()
         self.data_type = data_type.pop()
         self.descriptor = descriptor.pop()
-        self.file_path_list = file_path_list
+        self.file_obj_list = file_obj_list
 
     def construct_json_output(self):
         """Construct a JSON output.

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -7,9 +7,13 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
 
-from imap_data_access import AncillaryFilePath, ImapFilePath, ScienceFilePath, SPICEFilePath
+from imap_data_access import (
+    AncillaryFilePath,
+    ImapFilePath,
+    ScienceFilePath,
+    SPICEFilePath,
+)
 
 
 class ProcessingInputType(Enum):

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -42,8 +42,10 @@ class ProcessingInput(ABC):
 
     Attributes
     ----------
-    filepath_list : list[str]
-        A list of filepaths.
+    filename_list : list[str]
+        A list of filename(s).
+    file_obj_list : list[AncillaryFilePath, ScienceFilePath, SPICEFilePath]
+        A list of file objects, one for each filename.
     input_type : ProcessingInputType
         The type of input file.
     source : str
@@ -55,9 +57,7 @@ class ProcessingInput(ABC):
         A descriptor for the file, for example, "burst" or "cal".
     """
 
-    # List of filenames
     filename_list: list[str] = None
-    # List of download paths
     file_obj_list: list[AncillaryFilePath, ScienceFilePath, SPICEFilePath] = None
     input_type: ProcessingInputType = None
     # Following three are retrieved from dependency check.

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 
 from imap_data_access import AncillaryFilePath, ScienceFilePath, SPICEFilePath
 
@@ -54,7 +55,10 @@ class ProcessingInput(ABC):
         A descriptor for the file, for example, "burst" or "cal".
     """
 
+    # List of filenames
     filename_list: list[str] = None
+    # List of download paths
+    file_path_list: list[Path] = None
     input_type: ProcessingInputType = None
     # Following three are retrieved from dependency check.
     # But they can also come from the filename.
@@ -122,7 +126,8 @@ class ProcessingInput(ABC):
             else:
                 data_type.add(self.input_type.value)
             descriptor.add(path_validator.descriptor)
-            file_path_list.append(str(path_validator.filename))
+            # Store download path. This gets used in `imap_processing` cli
+            file_path_list.append(path_validator.construct_path())
 
         if len(source) != 1 or len(data_type) != 1 or len(descriptor) != 1:
             raise ValueError(
@@ -148,14 +153,7 @@ class ScienceInput(ProcessingInput):
 
     The class can contain multiple files, but they must have the same source, data type,
      and descriptor.
-
-    Attributes
-    ----------
-    science_file_paths : list[ScienceFilePath]
-        A list of ScienceFilePath objects.
     """
-
-    science_file_paths: list[ScienceFilePath] = None
 
     def __init__(self, *args):
         """Set the processing type to ScienceFile and then calls super().

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
-from imap_data_access import AncillaryFilePath, ScienceFilePath, SPICEFilePath
+from imap_data_access import AncillaryFilePath, ImapFilePath, ScienceFilePath, SPICEFilePath
 
 
 class ProcessingInputType(Enum):
@@ -44,7 +44,7 @@ class ProcessingInput(ABC):
     ----------
     filename_list : list[str]
         A list of filename(s).
-    file_obj_list : list[AncillaryFilePath, ScienceFilePath, SPICEFilePath]
+    imap_file_paths: list[ImapFilePath]
         A list of file objects, one for each filename.
     input_type : ProcessingInputType
         The type of input file.
@@ -58,7 +58,7 @@ class ProcessingInput(ABC):
     """
 
     filename_list: list[str] = None
-    file_obj_list: list[AncillaryFilePath, ScienceFilePath, SPICEFilePath] = None
+    imap_file_paths: list[ImapFilePath] = None
     input_type: ProcessingInputType = None
     # Following three are retrieved from dependency check.
     # But they can also come from the filename.

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -136,7 +136,7 @@ class ProcessingInput(ABC):
         self.source = source.pop()
         self.data_type = data_type.pop()
         self.descriptor = descriptor.pop()
-        self.file_obj_list = file_obj_list
+        self.imap_file_paths = file_obj_list
 
     def construct_json_output(self):
         """Construct a JSON output.

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -2,7 +2,12 @@ from datetime import datetime
 
 import pytest
 
-from imap_data_access import AncillaryFilePath, ScienceFilePath, SPICEFilePath, processing_input
+from imap_data_access import (
+    AncillaryFilePath,
+    ScienceFilePath,
+    SPICEFilePath,
+    processing_input,
+)
 from imap_data_access.processing_input import ProcessingInputType
 
 
@@ -59,7 +64,9 @@ def test_create_ancillary_files():
         "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
     ]
     assert len(two_files.imap_file_paths) == 2
-    assert all([isinstance(obj, AncillaryFilePath) for obj in two_files.imap_file_paths])
+    assert all(
+        [isinstance(obj, AncillaryFilePath) for obj in two_files.imap_file_paths]
+    )
     assert two_files.input_type == ProcessingInputType.ANCILLARY_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "l1b-cal"

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+
 import pytest
 
-from imap_data_access import processing_input, ScienceFilePath
+from imap_data_access import ScienceFilePath, processing_input
 from imap_data_access.processing_input import ProcessingInputType
 
 

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
 import pytest
+import numpy as np
 
-from imap_data_access import ScienceFilePath, processing_input
+from imap_data_access import AncillaryFilePath, ScienceFilePath, SPICEFilePath, processing_input
 from imap_data_access.processing_input import ProcessingInputType
 
 
@@ -16,7 +17,8 @@ def test_create_science_files():
     one_file_path = ScienceFilePath("imap_mag_l1a_norm-magi_20240312_v000.cdf")
 
     assert one_file.filename_list == ["imap_mag_l1a_norm-magi_20240312_v000.cdf"]
-    assert one_file.file_path_list == [one_file_path.construct_path()]
+    assert len(one_file.file_obj_list) == 1
+    assert isinstance(one_file.file_obj_list[0], ScienceFilePath)
     assert one_file.input_type == ProcessingInputType.SCIENCE_FILE
     assert one_file.source == "mag"
     assert one_file.descriptor == "norm-magi"
@@ -26,7 +28,8 @@ def test_create_science_files():
         "imap_mag_l1a_burst-magi_20240312_v000.cdf",
         "imap_mag_l1a_burst-magi_20240310_v000.cdf",
     ]
-    assert len(two_files.file_path_list) == 2
+    assert np.all([isinstance(obj, ScienceFilePath) for obj in two_files.file_obj_list])
+    assert len(two_files.file_obj_list) == 2
     assert two_files.input_type == ProcessingInputType.SCIENCE_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "burst-magi"
@@ -47,7 +50,8 @@ def test_create_ancillary_files():
     )
 
     assert one_file.filename_list == ["imap_mag_l1b-cal_20250101_v001.cdf"]
-    assert len(one_file.file_path_list) == 1
+    assert len(one_file.file_obj_list) == 1
+    assert isinstance(one_file.file_obj_list[0], AncillaryFilePath)
     assert one_file.input_type == ProcessingInputType.ANCILLARY_FILE
     assert one_file.source == "mag"
     assert one_file.descriptor == "l1b-cal"
@@ -57,7 +61,8 @@ def test_create_ancillary_files():
         "imap_mag_l1b-cal_20250101_v001.cdf",
         "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
     ]
-    assert len(two_files.file_path_list) == 2
+    assert len(two_files.file_obj_list) == 2
+    assert np.all([isinstance(obj, AncillaryFilePath) for obj in two_files.file_obj_list])
     assert two_files.input_type == ProcessingInputType.ANCILLARY_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "l1b-cal"
@@ -76,6 +81,8 @@ def test_create_spice_files():
     one_file = processing_input.SPICEInput("test.bc")
 
     assert one_file.filename_list == ["test.bc"]
+    assert len(one_file.file_obj_list) == 1
+    assert isinstance(one_file.file_obj_list[0], SPICEFilePath)
     assert one_file.input_type == ProcessingInputType.SPICE_FILE
     assert one_file.source == "spice"
 
@@ -116,8 +123,8 @@ def test_create_collection():
     assert len(science_files) == 2
     assert science_files[0].descriptor == "norm-magi"
     assert science_files[1].descriptor == "hist"
-    assert len(science_files[0].file_path_list) == 2
-    assert len(science_files[1].file_path_list) == 1
+    assert len(science_files[0].file_obj_list) == 2
+    assert len(science_files[1].file_obj_list) == 1
 
 
 def test_get_time_range():

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -14,8 +14,8 @@ def test_create_science_files():
     )
 
     assert one_file.filename_list == ["imap_mag_l1a_norm-magi_20240312_v000.cdf"]
-    assert len(one_file.file_obj_list) == 1
-    assert isinstance(one_file.file_obj_list[0], ScienceFilePath)
+    assert len(one_file.imap_file_paths) == 1
+    assert isinstance(one_file.imap_file_paths[0], ScienceFilePath)
     assert one_file.input_type == ProcessingInputType.SCIENCE_FILE
     assert one_file.source == "mag"
     assert one_file.descriptor == "norm-magi"
@@ -25,8 +25,8 @@ def test_create_science_files():
         "imap_mag_l1a_burst-magi_20240312_v000.cdf",
         "imap_mag_l1a_burst-magi_20240310_v000.cdf",
     ]
-    assert all([isinstance(obj, ScienceFilePath) for obj in two_files.file_obj_list])
-    assert len(two_files.file_obj_list) == 2
+    assert all([isinstance(obj, ScienceFilePath) for obj in two_files.imap_file_paths])
+    assert len(two_files.imap_file_paths) == 2
     assert two_files.input_type == ProcessingInputType.SCIENCE_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "burst-magi"
@@ -47,8 +47,8 @@ def test_create_ancillary_files():
     )
 
     assert one_file.filename_list == ["imap_mag_l1b-cal_20250101_v001.cdf"]
-    assert len(one_file.file_obj_list) == 1
-    assert isinstance(one_file.file_obj_list[0], AncillaryFilePath)
+    assert len(one_file.imap_file_paths) == 1
+    assert isinstance(one_file.imap_file_paths[0], AncillaryFilePath)
     assert one_file.input_type == ProcessingInputType.ANCILLARY_FILE
     assert one_file.source == "mag"
     assert one_file.descriptor == "l1b-cal"
@@ -58,8 +58,8 @@ def test_create_ancillary_files():
         "imap_mag_l1b-cal_20250101_v001.cdf",
         "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
     ]
-    assert len(two_files.file_obj_list) == 2
-    assert all([isinstance(obj, AncillaryFilePath) for obj in two_files.file_obj_list])
+    assert len(two_files.imap_file_paths) == 2
+    assert all([isinstance(obj, AncillaryFilePath) for obj in two_files.imap_file_paths])
     assert two_files.input_type == ProcessingInputType.ANCILLARY_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "l1b-cal"
@@ -78,8 +78,8 @@ def test_create_spice_files():
     one_file = processing_input.SPICEInput("test.bc")
 
     assert one_file.filename_list == ["test.bc"]
-    assert len(one_file.file_obj_list) == 1
-    assert isinstance(one_file.file_obj_list[0], SPICEFilePath)
+    assert len(one_file.imap_file_paths) == 1
+    assert isinstance(one_file.imap_file_paths[0], SPICEFilePath)
     assert one_file.input_type == ProcessingInputType.SPICE_FILE
     assert one_file.source == "spice"
 
@@ -120,8 +120,8 @@ def test_create_collection():
     assert len(science_files) == 2
     assert science_files[0].descriptor == "norm-magi"
     assert science_files[1].descriptor == "hist"
-    assert len(science_files[0].file_obj_list) == 2
-    assert len(science_files[1].file_obj_list) == 1
+    assert len(science_files[0].imap_file_paths) == 2
+    assert len(science_files[1].imap_file_paths) == 1
 
 
 def test_get_time_range():

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import pytest
-import numpy as np
 
 from imap_data_access import AncillaryFilePath, ScienceFilePath, SPICEFilePath, processing_input
 from imap_data_access.processing_input import ProcessingInputType
@@ -26,7 +25,7 @@ def test_create_science_files():
         "imap_mag_l1a_burst-magi_20240312_v000.cdf",
         "imap_mag_l1a_burst-magi_20240310_v000.cdf",
     ]
-    assert np.all([isinstance(obj, ScienceFilePath) for obj in two_files.file_obj_list])
+    assert all([isinstance(obj, ScienceFilePath) for obj in two_files.file_obj_list])
     assert len(two_files.file_obj_list) == 2
     assert two_files.input_type == ProcessingInputType.SCIENCE_FILE
     assert two_files.source == "mag"
@@ -60,7 +59,7 @@ def test_create_ancillary_files():
         "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
     ]
     assert len(two_files.file_obj_list) == 2
-    assert np.all([isinstance(obj, AncillaryFilePath) for obj in two_files.file_obj_list])
+    assert all([isinstance(obj, AncillaryFilePath) for obj in two_files.file_obj_list])
     assert two_files.input_type == ProcessingInputType.ANCILLARY_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "l1b-cal"

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -14,8 +14,6 @@ def test_create_science_files():
         "imap_mag_l1a_burst-magi_20240310_v000.cdf",
     )
 
-    one_file_path = ScienceFilePath("imap_mag_l1a_norm-magi_20240312_v000.cdf")
-
     assert one_file.filename_list == ["imap_mag_l1a_norm-magi_20240312_v000.cdf"]
     assert len(one_file.file_obj_list) == 1
     assert isinstance(one_file.file_obj_list[0], ScienceFilePath)

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-
 import pytest
 
-from imap_data_access import processing_input
+from imap_data_access import processing_input, ScienceFilePath
 from imap_data_access.processing_input import ProcessingInputType
 
 
@@ -13,16 +12,20 @@ def test_create_science_files():
         "imap_mag_l1a_burst-magi_20240310_v000.cdf",
     )
 
-    assert one_file.file_path_list == ["imap_mag_l1a_norm-magi_20240312_v000.cdf"]
+    one_file_path = ScienceFilePath("imap_mag_l1a_norm-magi_20240312_v000.cdf")
+
+    assert one_file.filename_list == ["imap_mag_l1a_norm-magi_20240312_v000.cdf"]
+    assert one_file.file_path_list == [one_file_path.construct_path()]
     assert one_file.input_type == ProcessingInputType.SCIENCE_FILE
     assert one_file.source == "mag"
     assert one_file.descriptor == "norm-magi"
     assert one_file.data_type == "l1a"
 
-    assert two_files.file_path_list == [
+    assert two_files.filename_list == [
         "imap_mag_l1a_burst-magi_20240312_v000.cdf",
         "imap_mag_l1a_burst-magi_20240310_v000.cdf",
     ]
+    assert len(two_files.file_path_list) == 2
     assert two_files.input_type == ProcessingInputType.SCIENCE_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "burst-magi"
@@ -42,16 +45,18 @@ def test_create_ancillary_files():
         "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
     )
 
-    assert one_file.file_path_list == ["imap_mag_l1b-cal_20250101_v001.cdf"]
+    assert one_file.filename_list == ["imap_mag_l1b-cal_20250101_v001.cdf"]
+    assert len(one_file.file_path_list) == 1
     assert one_file.input_type == ProcessingInputType.ANCILLARY_FILE
     assert one_file.source == "mag"
     assert one_file.descriptor == "l1b-cal"
     assert one_file.data_type == "ancillary"
 
-    assert two_files.file_path_list == [
+    assert two_files.filename_list == [
         "imap_mag_l1b-cal_20250101_v001.cdf",
         "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
     ]
+    assert len(two_files.file_path_list) == 2
     assert two_files.input_type == ProcessingInputType.ANCILLARY_FILE
     assert two_files.source == "mag"
     assert two_files.descriptor == "l1b-cal"
@@ -69,7 +74,7 @@ def test_create_ancillary_files():
 def test_create_spice_files():
     one_file = processing_input.SPICEInput("test.bc")
 
-    assert one_file.file_path_list == ["test.bc"]
+    assert one_file.filename_list == ["test.bc"]
     assert one_file.input_type == ProcessingInputType.SPICE_FILE
     assert one_file.source == "spice"
 


### PR DESCRIPTION
# Change Summary

## Overview
This is to simplify download dependency in general. Greg, Luisa and I discussed some approach and we thought this change may help on `imap_cli` update work. Right now in `cli.py`, we have to go through `filename_list` and then create `construct_path()` and then download each dependency files. Then we loose that information after download. With this change, we create download path list and store in the class and store in its `file_path_list` parameter. Then use that to download the file in `cli.py` and then return `InputCollection()` to all our instrument processing code.  Instrument processing code can use that information to look up their downloaded file from `file_path_list` and also allow them to have other additional informations from `InputCollection()` in processing, such as `input_type` or `descriptor` to decide what to with certain science or ancillary or spice input type.


## Updated Files
- imap_data_access/processing_input.py
   - Change to accommodate above plan


## Testing
- tests/test_processing_input.py
