### PR TITLE
MNT: Adding parameter to ProcessingInput

### DIFF
--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 
 from imap_data_access import (
     AncillaryFilePath,
@@ -61,6 +62,7 @@ class ProcessingInput(ABC):
         A descriptor for the file, for example, "burst" or "cal".
     """
 
+    # List of filenames
     filename_list: list[str] = None
     imap_file_paths: list[ImapFilePath] = None
     input_type: ProcessingInputType = None

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -51,6 +51,8 @@ class ProcessingInput(ABC):
         A list of filename(s).
     imap_file_paths: list[ImapFilePath]
         A list of file objects, one for each filename.
+    download_paths : list[Path]
+        A list of downloaded paths for each filename.
     input_type : ProcessingInputType
         The type of input file.
     source : str
@@ -65,6 +67,7 @@ class ProcessingInput(ABC):
     # List of filenames
     filename_list: list[str] = None
     imap_file_paths: list[ImapFilePath] = None
+    download_paths: list[Path] = None
     input_type: ProcessingInputType = None
     # Following three are retrieved from dependency check.
     # But they can also come from the filename.
@@ -123,6 +126,7 @@ class ProcessingInput(ABC):
         data_type = set()
         descriptor = set()
         file_obj_list = []
+        files_path = []
         for file in self.filename_list:
             path_validator = InputTypePathMapper[self.input_type.name].value(file)
 
@@ -133,6 +137,7 @@ class ProcessingInput(ABC):
                 data_type.add(self.input_type.value)
             descriptor.add(path_validator.descriptor)
             file_obj_list.append(path_validator)
+            files_path.append(path_validator.construct_path())
 
         if len(source) != 1 or len(data_type) != 1 or len(descriptor) != 1:
             raise ValueError(
@@ -143,6 +148,7 @@ class ProcessingInput(ABC):
         self.data_type = data_type.pop()
         self.descriptor = descriptor.pop()
         self.imap_file_paths = file_obj_list
+        self.download_paths = files_path
 
     def construct_json_output(self):
         """Construct a JSON output.

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 import pytest
 
 from imap_data_access import (


### PR DESCRIPTION
# Change Summary

## Overview
Adding parameter to ProcessingInput to simplify cli.py on imap_processing. We are needing to call `construct_path()` a lot on `imap_processing` since every instrument expects download path as input to their processing. Please look [here](https://github.com/IMAP-Science-Operations-Center/imap_processing/pull/1473/files) for the need of this new parameter

## Updated Files
- imap_data_access/processing_input.py
   - Code to add new parameter


## Testing
TODO: add tests once design is ok
