### PR TITLE
BUG: fixing ancillary filename convention

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -93,7 +93,7 @@ FILENAME_CONVENTION = (
 
 ANCILLARY_FILENAME_CONVENTION = (
     "<mission>_<instrument>_<description>_"
-    "<start_date>(-<end_date>)_<version>.<extension>"
+    "<start_date>(_<end_date>)_<version>.<extension>"
 )
 
 VALID_ANCILLARY_FILE_EXTENSION = {"cdf", "csv", "json"}

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -554,7 +554,7 @@ class AncillaryFilePath(ImapFilePath):
         """
         if end_time:
             filename = (
-                f"imap_{instrument}_{descriptor}_{start_time}-{end_time}_"
+                f"imap_{instrument}_{descriptor}_{start_time}_{end_time}_"
                 f"{version}.{extension}"
             )
         else:
@@ -664,7 +664,7 @@ class AncillaryFilePath(ImapFilePath):
             r"(?P<instrument>[^_]+)_"
             r"(?P<descriptor>[^_]+)_"
             r"(?P<start_date>\d{8})"
-            r"(-(?P<end_date>\d{8}))?"  # Optional end_date field
+            r"(_(?P<end_date>\d{8}))?"  # Optional end_date
             r"_(?P<version>v\d{3})"
             r"\.(?P<extension>cdf|csv|json)$"
         )

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -466,7 +466,7 @@ class AncillaryFilePath(ImapFilePath):
         path is set by the "IMAP_DATA_DIR" environment variable, or defaults to "data/"
 
         Current filename convention:
-        "<mission>_<instrument>_<descriptor>_<start_date>(-<end_date>)_
+        "<mission>_<instrument>_<descriptor>_<start_date>(_<end_date>)_
         <version>.<extension>"
 
         <mission>: imap

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -231,7 +231,7 @@ def test_ancillary_file_path():
         extension="cdf",
     )
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/ancillary/mag/imap_mag_test_20210101-20210102_v001.cdf"
+        "imap/ancillary/mag/imap_mag_test_20210101_20210102_v001.cdf"
     )
     assert ancillary_file_all_params.construct_path() == expected_output
 
@@ -273,3 +273,9 @@ def test_ancillary_file_path():
         "imap/ancillary/mag/imap_mag_test_20210101_v001.cdf"
     )
     assert ancillary_file_no_end_date.construct_path() == expected_output_no_end_date
+
+    # Test by passing the file
+    anc_file = "imap_mag_test_20210101_20210102_v001.csv"
+    ancillary_file = AncillaryFilePath(anc_file)
+    assert ancillary_file.instrument == "mag"
+    assert ancillary_file.end_date == "20210102"

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -48,7 +48,7 @@ def test_create_ancillary_files():
     one_file = processing_input.AncillaryInput("imap_mag_l1b-cal_20250101_v001.cdf")
     two_files = processing_input.AncillaryInput(
         "imap_mag_l1b-cal_20250101_v001.cdf",
-        "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
+        "imap_mag_l1b-cal_20250103_20250104_v002.cdf",
     )
 
     assert one_file.filename_list == ["imap_mag_l1b-cal_20250101_v001.cdf"]
@@ -61,7 +61,7 @@ def test_create_ancillary_files():
 
     assert two_files.filename_list == [
         "imap_mag_l1b-cal_20250101_v001.cdf",
-        "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
+        "imap_mag_l1b-cal_20250103_20250104_v002.cdf",
     ]
     assert len(two_files.imap_file_paths) == 2
     assert all(
@@ -75,7 +75,7 @@ def test_create_ancillary_files():
     with pytest.raises(ValueError, match="same source"):
         processing_input.AncillaryInput(
             "imap_mag_l1b-cal_20250101_v001.cdf",
-            "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
+            "imap_mag_l1b-cal_20250103_20250104_v002.cdf",
             "imap_mag_l1a-cal_20250105_v003.cdf",
         )
 
@@ -94,7 +94,7 @@ def test_create_spice_files():
 def test_create_collection():
     ancillary = processing_input.AncillaryInput(
         "imap_mag_l1b-cal_20250101_v001.cdf",
-        "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
+        "imap_mag_l1b-cal_20250103_20250104_v002.cdf",
     )
     science = processing_input.ScienceInput(
         "imap_mag_l1a_norm-magi_20240312_v000.cdf",
@@ -134,7 +134,7 @@ def test_create_collection():
 def test_get_time_range():
     ancillary = processing_input.AncillaryInput(
         "imap_mag_l1b-cal_20250101_v001.cdf",
-        "imap_mag_l1b-cal_20250103-20250104_v002.cdf",
+        "imap_mag_l1b-cal_20250103_20250104_v002.cdf",
     )
 
     start, end = ancillary.get_time_range()


### PR DESCRIPTION
# Change Summary

## Overview
Making updates to ancillary filename convention to match this [doc](https://imap-processing.readthedocs.io/en/latest/data-access/calibration-files.html) which instrument are using

## Updated Files

- imap_data_access/__init__.py
   - update to fix filename convention
- imap_data_access/file_validation.py 
   - updates to fix filename convention

## Testing
- tests/test_file_validation.py
