### PR TITLE
ENH: Add webpoda download capability to the project

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -38,6 +38,9 @@ config = {
     or "https://api.dev.imap-mission.com",
     "DATA_DIR": Path(os.getenv("IMAP_DATA_DIR") or Path.cwd() / "data"),
     "API_KEY": os.getenv("IMAP_API_KEY"),
+    # Create a base64 encoded string for the username and password
+    # echo -n 'username:password' | base64
+    "WEBPODA_TOKEN": os.getenv("IMAP_WEBPODA_TOKEN"),
 }
 """Settings configuration dictionary.
 
@@ -49,6 +52,10 @@ DATA_DIR : This is where the file data is stored and organized by instrument and
 API_KEY : This is the API key used to authenticate with the data access API.
     It can be set on the command line using the --api-key option, or through the
     environment variable IMAP_API_KEY. It is only necessary for uploading files.
+WEBPODA_TOKEN : This is the token used to authenticate with the webpoda API.
+    It can be set on the command line using the --webpoda-token option, or through
+    the environment variable IMAP_WEBPODA_TOKEN. It is only necessary for downloading
+    packet data.
 """
 
 

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -1,8 +1,5 @@
 """Input/output capabilities for the IMAP data processing pipeline."""
 
-# ruff: noqa: PLR0913 S310
-# too many arguments, but we want all of these explicitly listed
-# potentially unsafe usage of urlopen, but we aren't concerned here
 import contextlib
 import json
 import logging

--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -1,0 +1,342 @@
+"""Download all data since the last contact from webpoda.
+
+This script goes through and downloads all the newly arrived data from webpoda since
+the last contact.
+
+1. Iterate over each APID
+2. Make a query to webpoda for ERTs between the last contact time and now.
+3. Create a list of S/C dates with data from the last contact time.
+   NOTE: This is not the same as the ERTs because there could be backfilled gaps.
+4. Iterate over the S/C dates and download the binary data for each date.
+5. Save the data to a local file
+
+Location of list of APIDs and associated instruments:
+https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/155648242/Packet+Decommutation+Resource+Page+-+IMAP
+"""
+
+import datetime
+import logging
+import urllib.parse
+import urllib.request
+import urllib.response
+
+import imap_data_access
+from imap_data_access.io import _get_url_response
+
+logger = logging.getLogger(__name__)
+
+
+WEBPODA_APID_URL = "https://lasp.colorado.edu/ops/imap/poda/dap2/apids"
+# The system ID for the IMAP mission
+# SID1 == FLIGHT instrument telemetry and spacecraft telemetry after launch
+# SID2 == FLIGHT instrument telemetry and spacecraft telemetry before launch
+# SID3 == Instrument simulator telemetry and spacecraft simulator telemetry
+SYSTEM_ID = "SID2"
+
+# https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/155648242/Packet+Decommutation+Resource+Page+-+IMAP
+INSTRUMENT_APIDS = {
+    "codice": [
+        1136,
+        1152,
+        1153,
+        1155,
+        1156,
+        1157,
+        1158,
+        1159,
+        1160,
+        1161,
+        1162,
+        1168,
+        1169,
+        1170,
+        1171,
+        1172,
+        1173,
+        1174,
+    ],
+    "glows": [1445, 1448, 1449, 1480, 1481],
+    "hi": [754, 769, 770, 818, 833, 834, 818, 833, 834],
+    "hit": [1251, 1252, 1253],
+    "idex": [1377, 1420, 1424],
+    "lo": [673, 676, 677, 705, 706, 707, 708],
+    "mag": [1000, 1036, 1052, 1063, 1064, 1068, 1082],
+    "swapi": [1184, 1188],
+    "swe": [1330, 1334, 1344],
+    "ultra": [
+        865,
+        866,
+        867,
+        868,
+        869,
+        870,
+        871,
+        872,
+        873,
+        874,
+        875,
+        876,
+        877,
+        880,
+        881,
+        882,
+        883,
+        884,
+        885,
+        886,
+        887,
+        888,
+        889,
+        896,
+        897,
+        898,
+        899,
+        900,
+        901,
+        929,
+        930,
+        931,
+        932,
+        933,
+        934,
+        935,
+        936,
+        937,
+        938,
+        939,
+        940,
+        941,
+        944,
+        945,
+        946,
+        947,
+        948,
+        949,
+        950,
+        951,
+        952,
+        953,
+        960,
+        961,
+        962,
+        963,
+        964,
+        965,
+    ],
+    "spacecraft": [594],
+    "ialirt": [478],
+}
+
+
+def _add_webpoda_headers(request: urllib.request.Request) -> urllib.request.Request:
+    """Add the necessary headers for webpoda requests.
+
+    This function adds the necessary headers for webpoda requests to the provided
+    request object. It returns the modified request object.
+    """
+    if not imap_data_access.config.get("WEBPODA_TOKEN", ""):
+        raise ValueError(
+            "The IMAP_WEBPODA_TOKEN environment variable must be set. "
+            "You can run the following command to get the token: "
+            "echo -n 'username:password' | base64"
+        )
+    request.add_header(
+        "Authorization", f"Basic {imap_data_access.config['WEBPODA_TOKEN']}"
+    )
+    return request
+
+
+def get_packet_times_ert(
+    apid: int, start_time: datetime.datetime, end_time: datetime.datetime
+) -> list[datetime.datetime]:
+    """Get the packet dates for the apid between the start and end time.
+
+    This function makes a query to the webpoda API to get the packet dates
+    for the given APID between the start and end times in Earth Received Time (ERT).
+
+    Notes
+    -----
+    If we want just the first or last, we can add the take(1) or takeRight(1) to the
+    query string if needed. Without this, we'll get a list of all packets between
+    the start and end time.
+
+    Parameters
+    ----------
+    apid : int
+        The APID to query for.
+    start_time : datetime.datetime
+        The start time of the query in Earth Received Time (ERT).
+    end_time : datetime.datetime
+        The end time of the query in Earth Received Time (ERT).
+
+    Returns
+    -------
+    list[datetime.datetime]
+        A list of packet times for the given APID between the start and end time.
+    """
+    logger.debug(
+        f"Getting packet times for apid [{apid}] between "
+        f"{start_time} and {end_time}"
+    )
+
+    # Add a .txt suffix to get the data in text format back
+    query_range = f"{WEBPODA_APID_URL}/{SYSTEM_ID}/apid_{apid}.txt?"
+
+    # We need to properly encode the query string to make sure the special characters
+    # are handled correctly
+    query_range += urllib.parse.quote(
+        # Query the ERT field between start and end date
+        f'ert>={start_time.strftime("%Y-%m-%dT%H:%M:%S")}'
+        + f'&ert<={end_time.strftime("%Y-%m-%dT%H:%M:%S")}'
+        # only get the time (packet time)
+        # Represent all times in yyyy-MM-dd'T'HH:mm:ss format
+        + "&project(time)&formatTime(\"yyyy-MM-dd'T'HH:mm:ss\")"
+    )
+
+    request = urllib.request.Request(query_range, method="GET")
+    request = _add_webpoda_headers(request)
+    # Returns a text file with the packet times
+    # 2024-12-01T00:00:00
+    # 2024-12-01T00:00:01
+    with _get_url_response(request) as response:
+        data = response.read().decode().split("\n")
+
+    # Iterate over each line in the response, converting them to dates.
+    # We first strip the line to remove any whitespace (\r) and skip any trailing lines
+    return [
+        datetime.datetime.strptime(line.strip(), "%Y-%m-%dT%H:%M:%S")
+        for line in data
+        if line.strip()
+    ]
+
+
+def get_packet_binary_data_sctime(
+    apid: int, start_time: datetime.datetime, end_time: datetime.datetime
+) -> bytes:
+    """Get the binary packet data for the apid between the start and end time.
+
+    This function makes a query to the webpoda API to get the binary packet data
+    for the given APID between the start and end times in Spacecraft Time (SCT).
+
+    Parameters
+    ----------
+    apid : int
+        The APID to query for.
+    start_time : datetime.datetime
+        The start time of the query in Spacecraft Time (SCT).
+    end_time : datetime.datetime
+        The end time of the query in Spacecraft Time (SCT).
+
+    Returns
+    -------
+    bytes
+        The binary packet data for the given APID between the start and end time.
+    """
+    logger.debug(
+        "Getting binary packet data for apid [{apid}] between "
+        f"{start_time} and {end_time}"
+    )
+
+    # Add a .bin suffix to get the binary data back
+    query_range = f"{WEBPODA_APID_URL}/{SYSTEM_ID}/apid_{apid}.bin?"
+
+    # We need to properly encode the query string to make sure the special characters
+    # are handled correctly
+    query_range += urllib.parse.quote(
+        # Query the SCT field between start and end date
+        f'time>={start_time.strftime("%Y-%m-%dT%H:%M:%S")}'
+        + f'&time<={end_time.strftime("%Y-%m-%dT%H:%M:%S")}'
+        # only the raw packet data
+        + "&project(packet)"
+    )
+    request = urllib.request.Request(query_range, method="GET")
+    request = _add_webpoda_headers(request)
+
+    with _get_url_response(request) as response:
+        return response.read()
+
+
+def download_daily_data(
+    instrument: str,
+    start_time: datetime.datetime,
+    end_time: datetime.datetime,
+    version: str = "v001",
+    upload_to_server=False,
+):
+    """Download data for the apid and start/end time range from webpoda.
+
+    PODA stands for packet on demand access. This function requests the IMAP specific
+    API endpoint, so all APIDs must be from the IMAP mission.
+
+    The query is based on earth received time (ert), so all packets received during
+    a specific downlink to the ground, not the spacecraft time.
+
+    Parameters
+    ----------
+    instrument : str
+        The instrument to download data for.
+    start_time : datetime.datetime
+        The start time of the query in Earth Received Time (ERT).
+    end_time : datetime.datetime
+        The end time of the query in Earth Received Time (ERT).
+    version : str, optional
+        The version to use on the downloaded data file, by default "v001"
+    upload_to_server : bool, optional
+        If True, upload the data to the SDC data bucket, by default False
+    """
+    apids = INSTRUMENT_APIDS[instrument]
+    logger.info(f"Downloading data for instrument [{instrument}]")
+    # Make a query to get the timestamps of the packets during this ERT
+    # range. We can/will get packets outside of this range because of the way we are
+    # only getting data after the fact and potentially backfilling data gaps.
+    packet_times = [
+        p for apid in apids for p in get_packet_times_ert(apid, start_time, end_time)
+    ]
+
+    # Get the unique dates from the packet times
+    # TODO: Account for repointing times and filter out packets between repointings?
+    #       Filtering out at this point seems dangerous, we should probably try to
+    #       filter in the instrument processing stage instead.
+    unique_dates = set([dt.date() for dt in packet_times])
+    logger.info(
+        f"Found [{len(packet_times)}] packets for instrument [{instrument}] "
+        f"between earth received time {start_time} and {end_time}"
+    )
+    logger.info(f"Unique spacecraft dates with packets: {unique_dates}")
+
+    # Iterate over the packet dates to make a query for each individual spacecraft day
+    # packet_date 00:00:00 -> packet_date 23:59:59
+    for date in unique_dates:
+        science_file = imap_data_access.ScienceFilePath.generate_from_inputs(
+            instrument=instrument,
+            data_level="l0",
+            descriptor="raw",
+            start_time=date.strftime("%Y%m%d"),
+            version=version,
+        )
+        path = science_file.construct_path()
+        if path.exists():
+            logger.info(f"Skipping {path} because it already exists.")
+            continue
+
+        daily_start_time = datetime.datetime.combine(date, datetime.time.min)
+        daily_end_time = datetime.datetime.combine(date, datetime.time.max)
+
+        # Iterate over all apids, downloading the content for this time period
+        # concatenating all the binary returns into a single binary file
+        daily_packet_content = b"".join(
+            [
+                get_packet_binary_data_sctime(apid, daily_start_time, daily_end_time)
+                for apid in apids
+            ]
+        )
+
+        logger.info(
+            f"Saving binary data of size {len(daily_packet_content) // 1000} kB "
+            f"to {path}"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(daily_packet_content)
+        if upload_to_server:
+            # Upload the data to the server
+            imap_data_access.upload(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,5 @@ lint.ignore = ["D104", "D203", "D213", "D413", "PLR2004"]
 # S101: Use of assert detected
 "tests/*" = ["S101", "D"]
 "*.ipynb" = ["E501"]
+"imap_data_access/io.py" = ["PLR0913", "S310"]
+"imap_data_access/webpoda.py" = ["S310"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Global pytest configuration for the package."""
 
+from unittest.mock import patch
+
 import pytest
 
 import imap_data_access
@@ -12,3 +14,22 @@ def _set_global_config(monkeypatch: pytest.fixture, tmp_path: pytest.fixture):
     monkeypatch.setitem(
         imap_data_access.config, "DATA_ACCESS_URL", "https://api.test.com"
     )
+    # Make sure we don't leak any of this content if a user has set them locally
+    monkeypatch.setitem(imap_data_access.config, "API_KEY", "test_key")
+    monkeypatch.setitem(imap_data_access.config, "WEBPODA_TOKEN", "test_token")
+
+
+@pytest.fixture
+def mock_urlopen():
+    """Mock urlopen to return a file-like object.
+
+    Yields
+    ------
+    mock_urlopen : unittest.mock.MagicMock
+        Mock object for ``urlopen``
+    """
+    mock_data = b"Mock file content"
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = mock_urlopen.return_value.__enter__.return_value
+        mock_response.read.return_value = mock_data
+        yield mock_urlopen

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,22 +22,6 @@ test_science_filename = "imap_swe_l1_test-description_20100101_v000.cdf"
 test_science_path = "imap/swe/l1/2010/01/" + test_science_filename
 
 
-@pytest.fixture
-def mock_urlopen():
-    """Mock urlopen to return a file-like object.
-
-    Yields
-    ------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    """
-    mock_data = b"Mock file content"
-    with patch("urllib.request.urlopen") as mock_urlopen:
-        mock_response = mock_urlopen.return_value.__enter__.return_value
-        mock_response.read.return_value = mock_data
-        yield mock_urlopen
-
-
 def _set_mock_data(mock_urlopen: unittest.mock.MagicMock, data: bytes):
     """Set the data returned by the mock urlopen.
 
@@ -335,6 +319,7 @@ def test_upload(
     upload_file_path: str | Path,
     api_key: str | None,
     expected_header: dict,
+    monkeypatch,
 ):
     """Test a basic call to the upload API.
 
@@ -349,6 +334,7 @@ def test_upload(
     expected_header : dict
         The expected header to be sent with the request
     """
+    monkeypatch.setitem(imap_data_access.config, "API_KEY", None)
     _set_mock_data(mock_urlopen, b'"https://s3-test-bucket.com"')
     # Call the upload function
     file_to_upload = imap_data_access.config["DATA_DIR"] / upload_file_path

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -1,0 +1,98 @@
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import imap_data_access
+from imap_data_access import ScienceFilePath
+from imap_data_access.webpoda import (
+    INSTRUMENT_APIDS,
+    _add_webpoda_headers,
+    download_daily_data,
+    get_packet_binary_data_sctime,
+    get_packet_times_ert,
+)
+
+
+def test_add_webpoda_headers(monkeypatch):
+    request = MagicMock()
+    _add_webpoda_headers(request)
+    assert request.add_header.called
+    assert request.add_header.call_args[0][0] == "Authorization"
+    assert request.add_header.call_args[0][1] == "Basic test_token"
+
+    # Test that it raises with no authorization present
+    request = MagicMock()
+    monkeypatch.setitem(imap_data_access.config, "WEBPODA_TOKEN", None)
+    with pytest.raises(ValueError, match="The IMAP_WEBPODA_TOKEN"):
+        _add_webpoda_headers(request)
+
+
+@patch("imap_data_access.webpoda._get_url_response")
+def test_get_packet_times_ert(mock_get_response):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"2024-12-01T00:00:00\n2024-12-01T00:00:01\n"
+    mock_get_response.return_value.__enter__.return_value = mock_response
+
+    start_time = datetime.datetime(2024, 12, 1, 0, 0, 0)
+    end_time = datetime.datetime(2024, 12, 1, 23, 59, 59)
+    apid = 1136
+
+    result = get_packet_times_ert(apid, start_time, end_time)
+    assert len(result) == 2
+    assert result[0] == datetime.datetime(2024, 12, 1, 0, 0, 0)
+    assert result[1] == datetime.datetime(2024, 12, 1, 0, 0, 1)
+
+
+@patch("imap_data_access.webpoda._get_url_response")
+def test_get_packet_binary_data_sctime(mock_get_response):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"\x00\x01\x02\x03"
+    mock_get_response.return_value.__enter__.return_value = mock_response
+
+    start_time = datetime.datetime(2024, 12, 1, 0, 0, 0)
+    end_time = datetime.datetime(2024, 12, 1, 23, 59, 59)
+    apid = 1136
+
+    result = get_packet_binary_data_sctime(apid, start_time, end_time)
+    assert result == b"\x00\x01\x02\x03"
+
+
+@patch("imap_data_access.webpoda.get_packet_binary_data_sctime")
+@patch("imap_data_access.webpoda.get_packet_times_ert")
+@patch("imap_data_access.webpoda.imap_data_access.upload")
+@pytest.mark.parametrize("upload_to_server", [True, False])
+def test_download_daily_data(
+    mock_upload,
+    mock_get_packet_times_ert,
+    mock_get_packet_binary_data_sctime,
+    upload_to_server,
+):
+    mock_get_packet_times_ert.return_value = [
+        datetime.datetime(2024, 12, 1, 0, 0, 0),
+        datetime.datetime(2024, 12, 2, 0, 0, 0),
+    ]
+    mock_get_packet_binary_data_sctime.return_value = b"\x00\x01\x02\x03"
+
+    start_time = datetime.datetime(2024, 12, 1, 0, 0, 0)
+    end_time = datetime.datetime(2024, 12, 3, 23, 59, 59)
+    instrument = "swapi"
+
+    download_daily_data(
+        instrument, start_time, end_time, upload_to_server=upload_to_server
+    )
+
+    # We expect two daily files to be created because we have packets
+    # across two separate days
+    for day in mock_get_packet_times_ert.return_value:
+        expected_file_path = ScienceFilePath.generate_from_inputs(
+            instrument=instrument,
+            data_level="l0",
+            descriptor="raw",
+            start_time=day.strftime("%Y%m%d"),
+            version="v001",
+        ).construct_path()
+        # There are two swapi apids, so we download the same byte stream twice
+        n_apids = len(INSTRUMENT_APIDS[instrument])
+        assert expected_file_path.read_bytes() == b"\x00\x01\x02\x03" * n_apids
+        assert mock_upload.called is upload_to_server


### PR DESCRIPTION
# Change Summary

## Overview

We need to download L0 data from the POC. This brings the script I shared in Slack into our imap-data-access repository so we can use it across the project and keep all the io-related tasks in one repository. This helps to download the data to `IMAP_DATA_DIR` and generates the L0 filepath based on the ScienceFile requirements.

This is a separate URL on-premises. It requires authentication so we add a new `IMAP_WEBPODA_TOKEN` environment variable to get that externally.

Add a new cli subcommand to query webpoda specifically. Test with the following command.

```
imap-data-access webpoda --instrument swapi --start-date 20241202
```