### PR TITLE
MNT/REL: Update license formatting for setuptools build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
 
-  build_sdist:
-    name: Build source distribution
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
     outputs:
       SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
@@ -20,38 +20,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # We need the full history to generate the proper version number
-          fetch-depth: 0
+          persist-credentials: false
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: python -m pip install build twine
 
-      - name: Build sdist
-        id: sdist
+      - name: Build wheel and source tarball
         run: |
-          python -m build --sdist
-          # Get the name of the build sdist file for later use
-          echo "SDIST_NAME=$(ls -1 dist)" >> $GITHUB_OUTPUT
+          python -m build
 
-      - name: Check README rendering for PyPI
-        run: twine check dist/*
+      # TODO: Update once setuptools emits proper metadata for PEP 639
+      # - name: Check README rendering for PyPI
+      #   run: twine check dist/*
 
-      - name: Upload sdist result
+      - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
-          name: sdist
-          path: dist/*.tar.gz
+          name: python-package-distributions
+          path: dist/
           if-no-files-found: error
 
-  pypi-publish:
+  publish-to-pypi:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs: build_sdist
+    needs: build
     environment:
       name: pypi
       url: https://pypi.org/p/imap-data-access
@@ -59,11 +56,13 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-      - name: Download sdist
+      - name: Download all the dists
         uses: actions/download-artifact@v4
         with:
-          name: sdist
-          path: dist
+          name: python-package-distributions
+          path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verify-metadata: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
     branches:
-      - dev
       - main
   pull_request:
 
@@ -12,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     defaults:
       run:
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,17 @@ version = "0.15.1"
 description = "IMAP SDC Data Access"
 authors = [{name = "IMAP SDC Developers", email = "imap-sdc@lists.lasp.colorado.edu"}]
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 keywords = ["IMAP", "SDC", "SOC", "SDS", "Science Operations"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
I ran `twine check dist/*` locally and it still failed even with the newer setuptools 🤷  Just ignore the metadata for now. There are still open issues surrounding this upstream.

Update the CI Action to build the wheel distribution as well.

Following these steps to update the CI job: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/