### PR TITLE
ENH: Add ialirt and spacecraft as valid instruments

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -52,14 +52,18 @@ API_KEY : This is the API key used to authenticate with the data access API.
 """
 
 
+# NOTE: ialirt and spacecraft aren't actual instruments, but they are
+#       additional data sources for packet definitions and processing
 VALID_INSTRUMENTS = {
     "codice",
     "glows",
     "hit",
     "hi",
+    "ialirt",
     "idex",
     "lo",
     "mag",
+    "spacecraft",
     "swapi",
     "swe",
     "ultra",

--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -275,18 +275,7 @@ def main():  # noqa: PLR0915
         type=str,
         required=False,
         help="Name of the instrument",
-        choices=[
-            "codice",
-            "glows",
-            "hi",
-            "hit",
-            "idex",
-            "lo",
-            "mag",
-            "swapi",
-            "swe",
-            "ultra",
-        ],
+        choices=imap_data_access.VALID_INSTRUMENTS,
     )
     query_parser.add_argument(
         "--data-level",


### PR DESCRIPTION
`ialirt` and `spacecraft` aren't actual instruments, but they are additional data sources for packet definitions and processing. So we need to be able to specify these on the command lines and through validation functions.