### PR TITLE
Spice files

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -561,7 +561,7 @@ class SPICEFilePath(ImapFilePath):
                 f"Invalid SPICE file. Expected file to have one of the following "
                 f"file types {list(_SPICE_DIR_MAPPING.keys())}. Please reference "
                 f"the documentation to ensure the file has the "
-                f"proper naming convention "
+                f"proper naming convention."
             )
 
         components["type"] = _SPICE_TYPE_MAPPING[components["type"]]
@@ -591,6 +591,11 @@ class SPICEFilePath(ImapFilePath):
             raise SPICEFilePath.InvalidSPICEFileError(
                 "Invalid date detect in product file name, ensure date exists"
             ) from None
+
+        if "start_date" not in components:
+            components["start_date"] = None
+        if "end_date" not in components:
+            components["end_date"] = None
         return components
 
     @staticmethod
@@ -617,27 +622,21 @@ class SPICEFilePath(ImapFilePath):
             Dictionary containing components.
         """
         filename = Path(filename)
-        spice_metadata = None
         for regex in SPICEFilePath.valid_spice_regexes:
             m = regex.match(filename.name.lower())
             if m is not None:
                 spice_metadata = SPICEFilePath._spice_parts_handler(m.groupdict())
-                # Add the final fields
+                # Add the extension to the metadata
                 spice_metadata["extension"] = filename.suffix[1:]
-                if "start_date" not in spice_metadata:
-                    spice_metadata["start_date"] = None
-                if "end_date" not in spice_metadata:
-                    spice_metadata["end_date"] = None
                 return spice_metadata
 
         # Error if no match found to accepted types
-        if spice_metadata is None:
-            raise SPICEFilePath.InvalidSPICEFileError(
-                f"Invalid SPICE file. Expected file to have one of the following "
-                f"file types {list(_SPICE_DIR_MAPPING.keys())}. Please reference "
-                f"the documentation to ensure the file has the "
-                f"proper naming convention "
-            )
+        raise SPICEFilePath.InvalidSPICEFileError(
+            f"Invalid SPICE file. Expected file to have one of the following "
+            f"file types {list(_SPICE_DIR_MAPPING.keys())}. Please reference "
+            f"the documentation to ensure the file has the "
+            f"proper naming convention "
+        )
 
 
 class AncillaryFilePath(ImapFilePath):

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -99,33 +99,6 @@ class ImapFilePath:
         """Construct valid path from class variables and data_dir."""
         raise NotImplementedError
 
-    @staticmethod
-    def is_valid_doy(input_doy: str, input_year: str) -> bool:
-        """Check input day of year to ensure it is a valid one.
-
-        Parameters
-        ----------
-        input_doy : str
-            Date in '###' format.
-        input_year : str
-            Date in YYYY format.
-
-        Returns
-        -------
-        bool
-            Whether date input is valid or not
-        """
-        # Validate if it's a real date
-        try:
-            # This checks if date is in YYYYMMDD format.
-            # Sometimes, date is correct but not in the format we want
-            datetime(int(input_year), 1, 1) + datetime.timedelta(
-                days=int(input_doy) - 1
-            )
-            return True
-        except ValueError:
-            return False
-
 
 class ScienceFilePath(ImapFilePath):
     """Class for building and validating filepaths for science files."""

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -519,7 +519,9 @@ class SPICEFilePath(ImapFilePath):
             SPICE data filename or file path.
         """
         self.filename = Path(filename)
-        self.spice_metadata = SPICEFilePath.extract_filename_components(self.filename, ["type", "version"])
+        self.spice_metadata = SPICEFilePath.extract_filename_components(
+            self.filename, ["type", "version"]
+        )
         if self.spice_metadata is None:
             raise self.InvalidSPICEFileError(
                 f"Invalid SPICE file. Expected file to have one of the following "
@@ -544,6 +546,7 @@ class SPICEFilePath(ImapFilePath):
         # Use the file suffix to determine the directory structure
         # IMAP_DATA_DIR/spice/<subdir>/filename
         return spice_dir / subdir / self.filename
+
     @staticmethod
     def _matches_on_group(
         regex_list: Iterable[re.Pattern], string_to_parse: str
@@ -566,7 +569,7 @@ class SPICEFilePath(ImapFilePath):
             if m is not None:
                 return m
         return None
-    
+
     @staticmethod
     def _extract_parts(
         filename: Path | str,
@@ -622,8 +625,9 @@ class SPICEFilePath(ImapFilePath):
         return ret_val
 
     @staticmethod
-    def extract_filename_components(filename: Path | str,
-                                    parts: list[str] = ['type', 'version']) -> dict | None:
+    def extract_filename_components(
+        filename: Path | str, parts: list[str] = ["type", "version"]
+    ) -> dict | None:
         """Extract all components from filename.
 
         Will return a dictionary with the following keys:

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -436,7 +436,7 @@ class SPICEFilePath(ImapFilePath):
         r"(?P<start_doy>[\d]{3})_"
         r"(?P<end_year>[\d]{4})_"
         r"(?P<end_doy>[\d]{3})_"
-        r"(?P<version>[a-zA-Z0-9\-_]+)\."
+        r"(?P<version>[\d]+)\."
         r"(?P<type>ah.bc|ap.bc|spin.csv|repoint.csv)"
     )
     # Covers:

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -119,7 +119,9 @@ class ImapFilePath:
         try:
             # This checks if date is in YYYYMMDD format.
             # Sometimes, date is correct but not in the format we want
-            datetime(int(input_year), 1, 1) + datetime.timedelta(days=int(input_doy) - 1)
+            datetime(int(input_year), 1, 1) + datetime.timedelta(
+                days=int(input_doy) - 1
+            )
             return True
         except ValueError:
             return False

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -553,14 +553,14 @@ class SPICEFilePath(ImapFilePath):
     ) -> re.Match:
         """Determine the first regular expression that matches the provided string.
 
-        Arguments:
-        ---------
-            regex_list: list
-                A list of compiled regular expressions to be applied in order
-            string_to_parse: str
+        Parameters
+        ----------
+        regex_list: list
+            A list of compiled regular expressions to be applied in order
+        string_to_parse: str
                 The string to check against the provided regular expressions
 
-        Returns:
+        Returns
         -------
             The first match that satisfies a regular expression found in regex_list
         """
@@ -579,21 +579,21 @@ class SPICEFilePath(ImapFilePath):
     ) -> dict | None:
         """Extract the parts of a file.
 
-        Arguments:
-        ---------
-            filename: Path | str
-                A filename to extract parts from
-            parts: list[str]
-                A list of parts to be extracted from the filename
-            transforms: dict[str: func]
-                A dictionary of group->function (that takes 1 string) to
-                transform the string into some other type
-            handle_missing_parts: bool
-                If True, missing parts won't raise an exception and the result
-                set will contain None for the missing part.
-                If False, an IndexError is raised
+        Parameters
+        ----------
+        filename: Path | str
+            A filename to extract parts from
+        parts: list[str]
+            A list of parts to be extracted from the filename
+        transforms: dict[str: func]
+            A dictionary of group->function (that takes 1 string) to
+            transform the string into some other type
+        handle_missing_parts: bool
+            If True, missing parts won't raise an exception and the result
+            set will contain None for the missing part.
+            If False, an IndexError is raised
 
-        Returns:
+        Returns
         -------
             A dictionary of the parts that were requested or
             None if there were no matches for the provided regex_list
@@ -626,7 +626,7 @@ class SPICEFilePath(ImapFilePath):
 
     @staticmethod
     def extract_filename_components(
-        filename: Path | str, parts: list[str] = ["type", "version"]
+        filename: Path | str, parts: list[str]
     ) -> dict | None:
         """Extract all components from filename.
 
@@ -637,10 +637,10 @@ class SPICEFilePath(ImapFilePath):
 
         Parameters
         ----------
-            filename: Path | str
-                The filename to parse
-            parts: list[str]
-                The name of the sections to extract
+        filename : Path | str
+            The filename to parse
+        parts : list[str]
+            The name of the sections to extract
 
         Returns
         -------

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 from abc import abstractmethod
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 
@@ -430,13 +431,13 @@ class SPICEFilePath(ImapFilePath):
     # Spin Files (type: spin.csv)
     # Repoint Files (type: repoint.csv)
     attitude_file_pattern = (
-        r"(?P<{0}>imap)_"
-        r"(?P<{1}>[\d]{{4}})_"
-        r"(?P<{2}>[\d]{{3}})_"
-        r"(?P<{3}>[\d]{{4}})_"
-        r"(?P<{4}>[\d]{{3}})_"
-        r"(?P<{5}>[a-zA-Z0-9\-_]+)\."
-        r"(?P<{6}>ah.bc|ap.bc|spin.csv|repoint.csv)"
+        r"(?P<{}>imap)_"
+        r"(?P<{}>[\d]{{4}})_"
+        r"(?P<{}>[\d]{{3}})_"
+        r"(?P<{}>[\d]{{4}})_"
+        r"(?P<{}>[\d]{{3}})_"
+        r"(?P<{}>[a-zA-Z0-9\-_]+)\."
+        r"(?P<{}>ah.bc|ap.bc|spin.csv|repoint.csv)"
     ).format(
         "mission", "year_start", "doy_start", "year_end", "doy_end", "version", "type"
     )
@@ -449,12 +450,12 @@ class SPICEFilePath(ImapFilePath):
     # Long Term Predict (type: long)
     # Launch Predict (type: launch)
     spacecraft_ephemeris_file_pattern = (
-        r"(?P<{0}>imap)_"
-        r"(?P<{1}>[a-zA-Z0-9\-]+)_"
-        r"(?P<{2}>[\d]{{8}})_"
-        r"(?P<{3}>[\d]{{8}})"
-        r"(?:|_v(?P<{4}>[\d]*))\."
-        r"(?P<{5}>bsp)"
+        r"(?P<{}>imap)_"
+        r"(?P<{}>[a-zA-Z0-9\-]+)_"
+        r"(?P<{}>[\d]{{8}})_"
+        r"(?P<{}>[\d]{{8}})"
+        r"(?:|_v(?P<{}>[\d]*))\."
+        r"(?P<{}>bsp)"
     ).format("mission", "type", "date_start", "date_end", "version", "extension")
 
     # Covers:
@@ -463,40 +464,40 @@ class SPICEFilePath(ImapFilePath):
     # Leapsecond kernel (type: "naif")
     # Spacecraft clock kernel (type: "imapsclk_")
     spice_prod_ver_pattern = (
-        r"(?P<{0}>[a-zA-Z\-_]+)" r"(?P<{1}>[\d]+)\." r"(?P<{2}>tls|tpc|bsp|tsc)"
+        r"(?P<{}>[a-zA-Z\-_]+)" r"(?P<{}>[\d]+)\." r"(?P<{}>tls|tpc|bsp|tsc)"
     ).format("type", "version", "extension")
 
     # Covers:
     # Frame: (type: 'tf')
-    spice_frame_pattern = (r"(?P<{0}>imap)_" r"(?P<{1}>[\d]+)\." r"(?P<{2}>tf)").format(
+    spice_frame_pattern = (r"(?P<{}>imap)_" r"(?P<{}>[\d]+)\." r"(?P<{}>tf)").format(
         "mission", "version", "type"
     )
 
     # Covers:
     # Thruster files (type: sff)
     sff_filename_pattern = (
-        r"(?P<{0}>imap)_"
-        r"(?P<{1}>[\d]{{4}})_"
-        r"(?P<{2}>[\d]{{3}})_"
-        r"(?P<{3}>[a-zA-Z0-9\-_]+)_"
-        r"(?P<{4}>[\d]{{2}})\."
-        r"(?P<{5}>sff)"
+        r"(?P<{}>imap)_"
+        r"(?P<{}>[\d]{{4}})_"
+        r"(?P<{}>[\d]{{3}})_"
+        r"(?P<{}>[a-zA-Z0-9\-_]+)_"
+        r"(?P<{}>[\d]{{2}})\."
+        r"(?P<{}>sff)"
     ).format("mission", "year", "doy_start", "mode", "version", "type")
 
     # Covers:
     # Metakernels (type: 'tm')
     mk_filename_pattern = (
-        r"(?P<{0}>imap)_" r"(?P<{1}>[\d]{{4}})_" r"v(?P<{2}>[\d]{{3}})\." r"(?P<{3}>tm)"
+        r"(?P<{}>imap)_" r"(?P<{}>[\d]{{4}})_" r"v(?P<{}>[\d]{{3}})\." r"(?P<{}>tm)"
     ).format("mission", "year", "version", "type")
 
-    valid_spice_regexes = [
+    valid_spice_regexes = (
         re.compile(attitude_file_pattern),
         re.compile(spacecraft_ephemeris_file_pattern),
         re.compile(spice_prod_ver_pattern),
         re.compile(spice_frame_pattern),
         re.compile(sff_filename_pattern),
         re.compile(mk_filename_pattern),
-    ]
+    )
 
     class InvalidSPICEFileError(Exception):
         """Indicates a bad file type."""
@@ -523,7 +524,8 @@ class SPICEFilePath(ImapFilePath):
             raise self.InvalidSPICEFileError(
                 f"Invalid SPICE file. Expected file to have one of the following "
                 f"file types {list(_SPICE_DIR_MAPPING.keys())}. Please reference "
-                f"the documentation to ensure the file has the proper naming convention "
+                f"the documentation to ensure the file has the "
+                f"proper naming convention "
             )
 
     def construct_path(self) -> Path:
@@ -543,9 +545,10 @@ class SPICEFilePath(ImapFilePath):
         # IMAP_DATA_DIR/spice/<subdir>/filename
         return spice_dir / subdir / self.filename
 
-    def _matches_on_group(self, regex_list: list, string_to_parse: str) -> re.Match:
-        """Determine the first regular expression (in regex_list) that matches
-           the provided string_to_parse.
+    def _matches_on_group(
+        self, regex_list: Iterable[re.Pattern], string_to_parse: str
+    ) -> re.Match:
+        """Determine the first regular expression that matches the provided string.
 
         Arguments:
         ---------
@@ -574,7 +577,8 @@ class SPICEFilePath(ImapFilePath):
 
         Arguments:
         ---------
-            parts - A list of groups to be extracted
+            parts: list[str]
+                A list of parts to be extracted from the filename
             transforms: dict[str: func]
                 A dictionary of group->function (that takes 1 string) to
                 transform the string into some other type

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -466,8 +466,8 @@ class SPICEFilePath(ImapFilePath):
     # Repoint Files (type: repoint.csv)
     repoint_file_pattern = (
         r"(?P<mission>imap)_"
-        r"(?P<start_year>[\d]{4})_"
-        r"(?P<start_doy>[\d]{3})_"
+        r"(?P<end_year>[\d]{4})_"
+        r"(?P<end_doy>[\d]{3})_"
         r"(?P<version>[\d]+)\."
         r"(?P<type>repoint.csv)"
     )

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -370,7 +370,7 @@ _SPICE_TYPE_MAPPING = {
     "ah.bc": "attitude_history",
     "ap.bc": "attitude_predict",
     "spin.csv": "spin",
-    "repoint.csv": "repointing",
+    "repoint.csv": "repoint",
     "recon": "ephemeris_reconstructed",
     "nom": "ephemeris_nominal",
     "pred": "ephemeris_predicted",
@@ -390,7 +390,7 @@ _SPICE_DIR_MAPPING = {
     "attitude_history": "ck",
     "attitude_predict": "ck",
     "spin": "spin",
-    "repointing": "repoint",
+    "repoint": "repoint",
     "ephemeris_reconstructed": "spk",
     "ephemeris_nominal": "spk",
     "ephemeris_predicted": "spk",
@@ -588,8 +588,7 @@ class SPICEFilePath(ImapFilePath):
             A dictionary of the parts that were requested or
             None if there were no matches found
         """
-        if isinstance(filename, Path):
-            filename = filename.name
+        filename = Path(filename).name
 
         m = SPICEFilePath._matches_on_group(
             SPICEFilePath.valid_spice_regexes, filename.lower()

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -529,8 +529,8 @@ class SPICEFilePath(ImapFilePath):
         re.compile(mk_filename_pattern),
     )
 
-    EARLIEST_VALID_START_TIME = datetime(2023, 1, 1)
-    LATEST_VALID_END_TIME = datetime(2650, 1, 25)
+    EARLIEST_VALID_TIME = datetime(2023, 1, 1)
+    LATEST_VALID_TIME = datetime(2650, 1, 25)
 
     class InvalidSPICEFileError(Exception):
         """Indicates a bad file type."""
@@ -687,11 +687,9 @@ class SPICEFilePath(ImapFilePath):
                 spice_metadata = SPICEFilePath._spice_parts_handler(m.groupdict())
                 spice_metadata["extension"] = filename.suffix[1:]
                 if "start_date" not in spice_metadata:
-                    spice_metadata["start_date"] = (
-                        SPICEFilePath.EARLIEST_VALID_START_TIME
-                    )
+                    spice_metadata["start_date"] = SPICEFilePath.EARLIEST_VALID_TIME
                 if "end_date" not in spice_metadata:
-                    spice_metadata["end_date"] = SPICEFilePath.LATEST_VALID_END_TIME
+                    spice_metadata["end_date"] = SPICEFilePath.LATEST_VALID_TIME
                 break
 
         if spice_metadata is None:

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -429,7 +429,6 @@ class SPICEFilePath(ImapFilePath):
     # Historical Attitude (type: ah.bc)
     # Predicted Attitude (type: ap.bc)
     # Spin Files (type: spin.csv)
-    # Repoint Files (type: repoint.csv)
     attitude_file_pattern = (
         r"(?P<mission>imap)_"
         r"(?P<start_year>[\d]{4})_"
@@ -437,7 +436,16 @@ class SPICEFilePath(ImapFilePath):
         r"(?P<end_year>[\d]{4})_"
         r"(?P<end_doy>[\d]{3})_"
         r"(?P<version>[\d]+)\."
-        r"(?P<type>ah.bc|ap.bc|spin.csv|repoint.csv)"
+        r"(?P<type>ah.bc|ap.bc|spin.csv)"
+    )
+    # Covers:
+    # Repoint Files (type: repoint.csv)
+    repoint_file_pattern = (
+        r"(?P<mission>imap)_"
+        r"(?P<start_year>[\d]{4})_"
+        r"(?P<start_doy>[\d]{3})_"
+        r"(?P<version>[\d]+)\."
+        r"(?P<type>repoint.csv)"
     )
     # Covers:
     # Reconstructed (type: recon)
@@ -492,6 +500,7 @@ class SPICEFilePath(ImapFilePath):
 
     valid_spice_regexes = (
         re.compile(attitude_file_pattern),
+        re.compile(repoint_file_pattern),
         re.compile(spacecraft_ephemeris_file_pattern),
         re.compile(spice_prod_ver_pattern),
         re.compile(spice_frame_pattern),

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -365,41 +365,44 @@ class ScienceFilePath(ImapFilePath):
 # Commented out mappings are not being used on IMAP
 
 
-_SPICE_TYPE_MAPPING = {"ah.bc": "attitude_history",
-                        "ap.bc": "attitude_predict",
-                        "spin.csv": "spin",
-                        "repoint.csv": "repointing",
-                        "recon": "ephemeris_reconstructed",
-                        "nom": "ephemeris_nominal",
-                        "pred": "ephemeris_predicted",
-                        "90days": "ephemeris_90days",
-                        "long": "ephemeris_long",
-                        "launch": "ephemeris_launch",
-                        "de": "planetary_ephemeris",
-                        "pck": "planetary_constants",
-                        "naif": "leapseconds",
-                        "imapsclk_": "spacecraft_clock",
-                        "tf": "frames",
-                        "tm": "metakernel",
-                        "sff": "thruster"}
+_SPICE_TYPE_MAPPING = {
+    "ah.bc": "attitude_history",
+    "ap.bc": "attitude_predict",
+    "spin.csv": "spin",
+    "repoint.csv": "repointing",
+    "recon": "ephemeris_reconstructed",
+    "nom": "ephemeris_nominal",
+    "pred": "ephemeris_predicted",
+    "90days": "ephemeris_90days",
+    "long": "ephemeris_long",
+    "launch": "ephemeris_launch",
+    "de": "planetary_ephemeris",
+    "pck": "planetary_constants",
+    "naif": "leapseconds",
+    "imapsclk_": "spacecraft_clock",
+    "tf": "frames",
+    "tm": "metakernel",
+    "sff": "thruster",
+}
 
-_SPICE_DIR_MAPPING = {"attitude_history": "ck",
-                      "attitude_predict": "ck",
-                      "spin": "spin",
-                      "repointing": "repoint",
-                      "ephemeris_reconstructed": "spk",
-                      "ephemeris_nominal": "spk",
-                      "ephemeris_predicted": "spk",
-                      "ephemeris_90days": "spk",
-                      "ephemeris_long": "spk",
-                      "ephemeris_launch": "spk",
-                      "planetary_ephemeris": "spk",
-                      "planetary_constants": "pck",
-                      "leapseconds": "lsk",
-                      "spacecraft_clock": "sclk",
-                      "frames": "fk",
-                      "metakernel": "mk",
-                      "thruster": "activities"
+_SPICE_DIR_MAPPING = {
+    "attitude_history": "ck",
+    "attitude_predict": "ck",
+    "spin": "spin",
+    "repointing": "repoint",
+    "ephemeris_reconstructed": "spk",
+    "ephemeris_nominal": "spk",
+    "ephemeris_predicted": "spk",
+    "ephemeris_90days": "spk",
+    "ephemeris_long": "spk",
+    "ephemeris_launch": "spk",
+    "planetary_ephemeris": "spk",
+    "planetary_constants": "pck",
+    "leapseconds": "lsk",
+    "spacecraft_clock": "sclk",
+    "frames": "fk",
+    "metakernel": "mk",
+    "thruster": "activities",
 }
 """These are the valid extensions for SPICE files according to NAIF
 https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
@@ -421,94 +424,78 @@ https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html
 class SPICEFilePath(ImapFilePath):
     """Class for building and validating filepaths for SPICE files."""
 
-    #Covers:
+    # Covers:
     # Historical Attitude (type: ah.bc)
     # Predicted Attitude (type: ap.bc)
     # Spin Files (type: spin.csv)
     # Repoint Files (type: repoint.csv)
-    attitude_file_pattern = (r'(?P<{0}>imap)_'
-                            r'(?P<{1}>[\d]{{4}})_'
-                            r'(?P<{2}>[\d]{{3}})_'
-                            r'(?P<{3}>[\d]{{4}})_'
-                            r'(?P<{4}>[\d]{{3}})_'
-                            r'(?P<{5}>[a-zA-Z0-9\-_]+)\.'
-                            r'(?P<{6}>ah.bc|ap.bc|spin.csv|repoint.csv)').format('mission',
-                                                                                'year_start', 
-                                                                                'doy_start',
-                                                                                'year_end',
-                                                                                'doy_end',
-                                                                                'version',
-                                                                                'type')
-    
-    #Covers:
+    attitude_file_pattern = (
+        r"(?P<{0}>imap)_"
+        r"(?P<{1}>[\d]{{4}})_"
+        r"(?P<{2}>[\d]{{3}})_"
+        r"(?P<{3}>[\d]{{4}})_"
+        r"(?P<{4}>[\d]{{3}})_"
+        r"(?P<{5}>[a-zA-Z0-9\-_]+)\."
+        r"(?P<{6}>ah.bc|ap.bc|spin.csv|repoint.csv)"
+    ).format(
+        "mission", "year_start", "doy_start", "year_end", "doy_end", "version", "type"
+    )
+
+    # Covers:
     # Reconstructed (type: recon)
     # Nominal (type: nom)
     # Predict (type: pred)
     # 90 Day Predict (type: 90days)
     # Long Term Predict (type: long)
     # Launch Predict (type: launch)
-    spacecraft_ephemeris_file_pattern = (r'(?P<{0}>imap)_'
-                                        r'(?P<{1}>[a-zA-Z0-9\-]+)_'
-                                        r'(?P<{2}>[\d]{{8}})_'
-                                        r'(?P<{3}>[\d]{{8}})'
-                                        r'(?:|_v(?P<{4}>[\d]*))\.'
-                                        r'(?P<{5}>bsp)').format('mission',
-                                                                'type',
-                                                                'date_start',
-                                                                'date_end',
-                                                                'version',
-                                                                'extension')
+    spacecraft_ephemeris_file_pattern = (
+        r"(?P<{0}>imap)_"
+        r"(?P<{1}>[a-zA-Z0-9\-]+)_"
+        r"(?P<{2}>[\d]{{8}})_"
+        r"(?P<{3}>[\d]{{8}})"
+        r"(?:|_v(?P<{4}>[\d]*))\."
+        r"(?P<{5}>bsp)"
+    ).format("mission", "type", "date_start", "date_end", "version", "extension")
 
-    #Covers: 
+    # Covers:
     # Planetary Ephemeris (type: "de")
     # Planetary Constants (type: "pck")
     # Leapsecond kernel (type: "naif")
     # Spacecraft clock kernel (type: "imapsclk_")
-    spice_prod_ver_pattern = (r'(?P<{0}>[a-zA-Z\-_]+)'
-                            r'(?P<{1}>[\d]+)\.'
-                            r'(?P<{2}>tls|tpc|bsp|tsc)').format('type',
-                                                                'version',
-                                                                'extension')
+    spice_prod_ver_pattern = (
+        r"(?P<{0}>[a-zA-Z\-_]+)" r"(?P<{1}>[\d]+)\." r"(?P<{2}>tls|tpc|bsp|tsc)"
+    ).format("type", "version", "extension")
 
-    #Covers:
+    # Covers:
     # Frame: (type: 'tf')
-    spice_frame_pattern = (r'(?P<{0}>imap)_'
-                                r'(?P<{1}>[\d]+)\.'
-                                r'(?P<{2}>tf)').format('mission',
-                                                       'version',
-                                                       'type')
+    spice_frame_pattern = (r"(?P<{0}>imap)_" r"(?P<{1}>[\d]+)\." r"(?P<{2}>tf)").format(
+        "mission", "version", "type"
+    )
 
-    #Covers:
+    # Covers:
     # Thruster files (type: sff)
-    sff_filename_pattern = (r'(?P<{0}>imap)_'
-                            r'(?P<{1}>[\d]{{4}})_'
-                            r'(?P<{2}>[\d]{{3}})_'
-                            r'(?P<{3}>[a-zA-Z0-9\-_]+)_'
-                            r'(?P<{4}>[\d]{{2}})\.'
-                            r'(?P<{5}>sff)').format('mission',
-                                                    'year',
-                                                    'doy_start',
-                                                    'mode',
-                                                    'version',
-                                                    'type')
+    sff_filename_pattern = (
+        r"(?P<{0}>imap)_"
+        r"(?P<{1}>[\d]{{4}})_"
+        r"(?P<{2}>[\d]{{3}})_"
+        r"(?P<{3}>[a-zA-Z0-9\-_]+)_"
+        r"(?P<{4}>[\d]{{2}})\."
+        r"(?P<{5}>sff)"
+    ).format("mission", "year", "doy_start", "mode", "version", "type")
 
-    #Covers:
+    # Covers:
     # Metakernels (type: 'tm')
-    mk_filename_pattern = (r'(?P<{0}>imap)_'
-                            r'(?P<{1}>[\d]{{4}})_'
-                            r'v(?P<{2}>[\d]{{3}})\.'
-                            r'(?P<{3}>tm)').format('mission',
-                                                    'year',
-                                                    'version',
-                                                    'type')
+    mk_filename_pattern = (
+        r"(?P<{0}>imap)_" r"(?P<{1}>[\d]{{4}})_" r"v(?P<{2}>[\d]{{3}})\." r"(?P<{3}>tm)"
+    ).format("mission", "year", "version", "type")
 
-    valid_spice_regexes = [re.compile(attitude_file_pattern),
-                           re.compile(spacecraft_ephemeris_file_pattern),
-                           re.compile(spice_prod_ver_pattern),
-                           re.compile(spice_frame_pattern),
-                           re.compile(sff_filename_pattern),
-                           re.compile(mk_filename_pattern),
-                           
+    valid_spice_regexes = [
+        re.compile(attitude_file_pattern),
+        re.compile(spacecraft_ephemeris_file_pattern),
+        re.compile(spice_prod_ver_pattern),
+        re.compile(spice_frame_pattern),
+        re.compile(sff_filename_pattern),
+        re.compile(mk_filename_pattern),
     ]
 
     class InvalidSPICEFileError(Exception):
@@ -551,36 +538,38 @@ class SPICEFilePath(ImapFilePath):
             Upload path
         """
         spice_dir = imap_data_access.config["DATA_DIR"] / "spice"
-        subdir = _SPICE_DIR_MAPPING[self.spice_metadata['type']]
+        subdir = _SPICE_DIR_MAPPING[self.spice_metadata["type"]]
         # Use the file suffix to determine the directory structure
         # IMAP_DATA_DIR/spice/<subdir>/filename
         return spice_dir / subdir / self.filename
-    
-    def _matches_on_group(self, regex_list: list, string_to_parse: str)->re.Match:
-        '''
-        Method used to determine the first regular expression (in regex_list) that matches the provided string_to_parse
 
-        Arguments
+    def _matches_on_group(self, regex_list: list, string_to_parse: str) -> re.Match:
+        """Method used to determine the first regular expression (in regex_list) that matches the provided string_to_parse
+
+        Arguments:
         ---------
             regex_list - A list of compiled regular expressions to be applied in order
             string_to_parse - The string to check against the provided regular expressions
 
-        Returns
+        Returns:
         -------
             The first match that satisfies a regular expression found in regex_list
-        '''
+        """
         for regex in regex_list:
             m = regex.match(string_to_parse)
             if m is not None:
                 return m
         return None
 
-    def _extract_parts(self, parts: list[str], 
-                       transforms: dict | None =None, 
-                       handle_missing_parts: bool = False):
-        '''
-        Method used to extract the groups provided in order or None if no provided regular expressions match
-        Arguments
+    def _extract_parts(
+        self,
+        parts: list[str],
+        transforms: dict | None = None,
+        handle_missing_parts: bool = False,
+    ):
+        """Method used to extract the groups provided in order or None if no provided regular expressions match
+
+        Arguments:
         ---------
             regex_list - A list of compiled regular expressions to be applied in order
             string_to_parse - The string to check against the provided regular expressions
@@ -588,12 +577,14 @@ class SPICEFilePath(ImapFilePath):
             transforms - A dictionary of group->function (that takes 1 string) to transform the string into some other type
             handle_missing_parts - If True, missing parts won't raise an exception and the result set will contain None
                                 for the missing part.  If False, an IndexError is raised
-        Returns
+
+        Returns:
         -------
             A tuple of the groups that were requested in parts or None if there were no matches for the provided regex_list
-        '''
-        m = self._matches_on_group(SPICEFilePath.valid_spice_regexes, 
-                                   self.filename.name.lower())
+        """
+        m = self._matches_on_group(
+            SPICEFilePath.valid_spice_regexes, self.filename.name.lower()
+        )
         if not m:
             return None
         ret_val = {}
@@ -603,7 +594,7 @@ class SPICEFilePath(ImapFilePath):
                     ret_val[part] = transforms[part](m.group(part))
                 else:
                     ret_val[part] = m.group(part)
-            except IndexError as ie:
+            except IndexError:
                 if handle_missing_parts:
                     if transforms is not None and part in transforms:
                         ret_val[part] = transforms[part](None)
@@ -613,21 +604,21 @@ class SPICEFilePath(ImapFilePath):
                     ret_val[part] = None
 
         return ret_val
-    
+
     @staticmethod
     def _spice_type_name_transform(type: str) -> str:
         """Converts the type extracted from the filename to a more readable name.
 
-        Arguments
+        Arguments:
         ---------
             type: str
                 The type of file as retrieved from the file name
-        Returns
+
+        Returns:
         -------
             spice_type: str
                 A human-readable file type
         """
-        
         if type in _SPICE_TYPE_MAPPING:
             return _SPICE_TYPE_MAPPING[type]
         else:
@@ -646,13 +637,16 @@ class SPICEFilePath(ImapFilePath):
         components : dict
             Dictionary containing components.
         """
-
-        spice_metadata = self._extract_parts(['type', 'version'],
-                                             transforms={'type': 
-                                                         SPICEFilePath._spice_type_name_transform,
-                                                         'version': lambda x: int(x)})
+        spice_metadata = self._extract_parts(
+            ["type", "version"],
+            transforms={
+                "type": SPICEFilePath._spice_type_name_transform,
+                "version": lambda x: int(x),
+            },
+        )
 
         return spice_metadata
+
 
 class AncillaryFilePath(ImapFilePath):
     """Class for building and validating filepaths for Ancillary files."""

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -544,12 +544,15 @@ class SPICEFilePath(ImapFilePath):
         return spice_dir / subdir / self.filename
 
     def _matches_on_group(self, regex_list: list, string_to_parse: str) -> re.Match:
-        """Method used to determine the first regular expression (in regex_list) that matches the provided string_to_parse
+        """Determine the first regular expression (in regex_list) that matches
+           the provided string_to_parse.
 
         Arguments:
         ---------
-            regex_list - A list of compiled regular expressions to be applied in order
-            string_to_parse - The string to check against the provided regular expressions
+            regex_list: list
+                A list of compiled regular expressions to be applied in order
+            string_to_parse: str
+                The string to check against the provided regular expressions
 
         Returns:
         -------
@@ -566,21 +569,24 @@ class SPICEFilePath(ImapFilePath):
         parts: list[str],
         transforms: dict | None = None,
         handle_missing_parts: bool = False,
-    ):
-        """Method used to extract the groups provided in order or None if no provided regular expressions match
+    ) -> dict | None:
+        """Extract the parts of a file.
 
         Arguments:
         ---------
-            regex_list - A list of compiled regular expressions to be applied in order
-            string_to_parse - The string to check against the provided regular expressions
             parts - A list of groups to be extracted
-            transforms - A dictionary of group->function (that takes 1 string) to transform the string into some other type
-            handle_missing_parts - If True, missing parts won't raise an exception and the result set will contain None
-                                for the missing part.  If False, an IndexError is raised
+            transforms: dict[str: func]
+                A dictionary of group->function (that takes 1 string) to
+                transform the string into some other type
+            handle_missing_parts: bool
+                If True, missing parts won't raise an exception and the result
+                set will contain None for the missing part.
+                If False, an IndexError is raised
 
         Returns:
         -------
-            A tuple of the groups that were requested in parts or None if there were no matches for the provided regex_list
+            A dictionary of the parts that were requested or
+            None if there were no matches for the provided regex_list
         """
         m = self._matches_on_group(
             SPICEFilePath.valid_spice_regexes, self.filename.name.lower()
@@ -607,7 +613,7 @@ class SPICEFilePath(ImapFilePath):
 
     @staticmethod
     def _spice_type_name_transform(type: str) -> str:
-        """Converts the type extracted from the filename to a more readable name.
+        """Convert the type extracted from the filename to a more readable name.
 
         Arguments:
         ---------
@@ -624,13 +630,13 @@ class SPICEFilePath(ImapFilePath):
         else:
             return type
 
-    def extract_filename_components(self) -> dict:
+    def extract_filename_components(self) -> dict | None:
         """Extract all components from filename.
 
         Will return a dictionary with the following keys:
         { type, version }
 
-        If a match is not found, a ValueError will be raised.
+        If a match is not found, None will be returned
 
         Returns
         -------

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -119,7 +119,7 @@ class ImapFilePath:
         try:
             # This checks if date is in YYYYMMDD format.
             # Sometimes, date is correct but not in the format we want
-            datetime(input_year, 1, 1) + datetime.timedelta(days=input_doy - 1)
+            datetime(int(input_year), 1, 1) + datetime.timedelta(days=int(input_doy) - 1)
             return True
         except ValueError:
             return False

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -615,25 +615,6 @@ class SPICEFilePath(ImapFilePath):
 
         return ret_val
 
-    @staticmethod
-    def _spice_type_name_transform(type: str) -> str:
-        """Convert the type extracted from the filename to a more readable name.
-
-        Arguments:
-        ---------
-            type: str
-                The type of file as retrieved from the file name
-
-        Returns:
-        -------
-            spice_type: str
-                A human-readable file type
-        """
-        if type in _SPICE_TYPE_MAPPING:
-            return _SPICE_TYPE_MAPPING[type]
-        else:
-            return type
-
     def extract_filename_components(self) -> dict | None:
         """Extract all components from filename.
 
@@ -650,7 +631,7 @@ class SPICEFilePath(ImapFilePath):
         spice_metadata = self._extract_parts(
             ["type", "version"],
             transforms={
-                "type": SPICEFilePath._spice_type_name_transform,
+                "type": lambda x: _SPICE_TYPE_MAPPING.get(x, None),
                 "version": lambda x: int(x),
             },
         )

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -268,8 +268,8 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
-    assert file_path.spice_metadata["start_year"] == 2025
-    assert file_path.spice_metadata["start_doy"] == 230
+    assert file_path.spice_metadata["end_year"] == 2025
+    assert file_path.spice_metadata["end_doy"] == 230
 
 
 def test_spice_invalid_dates():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -177,9 +177,9 @@ def test_generate_from_inputs():
 
 def test_spice_file_path():
     """Tests the ``SPICEFilePath`` class."""
-    file_path = SPICEFilePath("test.bc")
+    file_path = SPICEFilePath("imap_0000_000_0000_000_01.ap.bc")
     assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/ck/test.bc"
+        "spice/ck/imap_0000_000_0000_000_01.ap.bc"
     )
 
     # Test a bad file extension too
@@ -197,15 +197,56 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("spice/repoint/imap_2025_122_2025_122_01.repoint.csv")
 
-    metakernel_file = SPICEFilePath("imap_yyyy_doy_e00.mk")
+    metakernel_file = SPICEFilePath("imap_0000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/mk/imap_yyyy_doy_e00.mk")
+    ] / Path("spice/mk/imap_0000_v000.tm")
 
-    thruster_file = SPICEFilePath("imap_yyyy_doy_hist_00.sff")
+    thruster_file = SPICEFilePath("imap_0000_000_hist_00.sff")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/activities/imap_yyyy_doy_hist_00.sff"
+        "spice/activities/imap_0000_000_hist_00.sff"
     )
+
+def test_spice_extract_parts():
+    # Test spin
+    file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
+    assert file_path.spice_metadata['version'] == 1
+    assert file_path.spice_metadata['type'] == 'spin'
+
+    # Test metakernel
+    file_path = SPICEFilePath("imap_2025_v100.tm")
+    assert file_path.spice_metadata['version'] == 100
+    assert file_path.spice_metadata['type'] == 'metakernel'
+
+    # Test attitude
+    file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
+    assert file_path.spice_metadata['version'] == 3
+    assert file_path.spice_metadata['type'] == 'attitude_history'
+
+    # Test leapsecond
+    file_path = SPICEFilePath("naif0012.tls")
+    assert file_path.spice_metadata['version'] == 12
+    assert file_path.spice_metadata['type'] == 'leapseconds'
+
+    # Test planetary ephemeris
+    file_path = SPICEFilePath("de440.bsp")
+    assert file_path.spice_metadata['version'] == 440
+    assert file_path.spice_metadata['type'] == 'planetary_ephemeris'
+
+    # Test planetary constants
+    file_path = SPICEFilePath("pck00010.tpc")
+    assert file_path.spice_metadata['version'] == 10
+    assert file_path.spice_metadata['type'] == 'planetary_constants'
+
+    # Test spacecraft ephemeris 
+    file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
+    assert file_path.spice_metadata['version'] == 1
+    assert file_path.spice_metadata['type'] == 'ephemeris_90days'
+
+    # Test repoint
+    file_path = SPICEFilePath("imap_2025_230_2025_230_01.repoint.csv")
+    assert file_path.spice_metadata['version'] == 1
+    assert file_path.spice_metadata['type'] == 'repointing'
 
 
 def test_ancillary_file_path():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -214,53 +214,48 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "spin"
-    assert file_path.spice_metadata["start_year_doy"] == "2025_122"
-    assert file_path.spice_metadata["end_year_doy"] == "2025_122"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_122", "%Y_%j"
     )
     assert file_path.spice_metadata["end_date"] == datetime.strptime(
         "2025_122", "%Y_%j"
     )
-
+    assert len(file_path.spice_metadata) == 5
     # Test metakernel
     file_path = SPICEFilePath("imap_2025_v100.tm")
     assert file_path.spice_metadata["version"] == 100
     assert file_path.spice_metadata["type"] == "metakernel"
-    assert file_path.spice_metadata["start_year"] == 2025
     assert file_path.spice_metadata["start_date"] == datetime(2025, 1, 1)
-
+    assert len(file_path.spice_metadata) == 5
     # Test attitude
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
     assert file_path.spice_metadata["version"] == 3
     assert file_path.spice_metadata["type"] == "attitude_history"
-    assert file_path.spice_metadata["start_year_doy"] == "2025_032"
-    assert file_path.spice_metadata["end_year_doy"] == "2025_034"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_032", "%Y_%j"
     )
     assert file_path.spice_metadata["end_date"] == datetime.strptime(
         "2025_034", "%Y_%j"
     )
-
+    assert len(file_path.spice_metadata) == 5
     # Test leapsecond
     file_path = SPICEFilePath("naif0012.tls")
     assert file_path.spice_metadata["version"] == 12
     assert file_path.spice_metadata["type"] == "leapseconds"
     assert file_path.spice_metadata["extension"] == "tls"
-
+    assert len(file_path.spice_metadata) == 5
     # Test planetary ephemeris
     file_path = SPICEFilePath("de440.bsp")
     assert file_path.spice_metadata["version"] == 440
     assert file_path.spice_metadata["type"] == "planetary_ephemeris"
     assert file_path.spice_metadata["extension"] == "bsp"
-
+    assert len(file_path.spice_metadata) == 5
     # Test planetary constants
     file_path = SPICEFilePath("pck00010.tpc")
     assert file_path.spice_metadata["version"] == 10
     assert file_path.spice_metadata["type"] == "planetary_constants"
     assert file_path.spice_metadata["extension"] == "tpc"
-
+    assert len(file_path.spice_metadata) == 5
     # Test spacecraft ephemeris
     file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
     assert file_path.spice_metadata["version"] == 1
@@ -272,15 +267,15 @@ def test_spice_extract_parts():
         "20260220", "%Y%m%d"
     )
     assert file_path.spice_metadata["extension"] == "bsp"
-
+    assert len(file_path.spice_metadata) == 5
     # Test repoint
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
-    assert file_path.spice_metadata["end_year_doy"] == "2025_230"
     assert file_path.spice_metadata["end_date"] == datetime.strptime(
         "2025_230", "%Y_%j"
     )
+    assert len(file_path.spice_metadata) == 5
 
 
 def test_spice_invalid_dates():
@@ -302,14 +297,10 @@ def test_spice_extract_parts_static_method():
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_122_2025_122_01.spin.csv"
     )
-    assert file_parts["mission"] == "imap"
 
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_032_2025_034_003.ah.bc",
     )
-    assert file_parts["mission"] == "imap"
-    assert file_parts["start_year_doy"] == "2025_032"
-    assert file_parts["end_year_doy"] == "2025_034"
     assert file_parts["version"] == 3
     assert file_parts["type"] == "attitude_history"
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -275,15 +275,15 @@ def test_spice_extract_parts():
 def test_spice_invalid_dates():
     # Ensure the DOY is valid (DOY 410??)
     with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
-        file_path = SPICEFilePath("imap_2025_032_2025_410_003.ah.bc")
+        SPICEFilePath("imap_2025_032_2025_410_003.ah.bc")
 
     # Ensure dates are valid (Month 13??)
     with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
-        file_path = SPICEFilePath("imap_90days_20251320_20260220_v01.bsp")
+        SPICEFilePath("imap_90days_20251320_20260220_v01.bsp")
 
     # Ensure valid ephemeris type (type taco??)
     with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
-        file_path = SPICEFilePath("imap_taco_20251320_20260220_v01.bsp")
+        SPICEFilePath("imap_taco_20251320_20260220_v01.bsp")
 
 
 def test_spice_extract_parts_static_method():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -209,7 +209,7 @@ def test_spice_file_path():
     )
 
 
-def test_spice_extract_parts():
+def test_spice_extract_spin_parts():
     # Test spin
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
     assert file_path.spice_metadata["version"] == 1
@@ -221,13 +221,17 @@ def test_spice_extract_parts():
         "2025_122", "%Y_%j"
     )
     assert len(file_path.spice_metadata) == 5
-    # Test metakernel
+
+
+def test_spice_extract_metakernel_parts():
     file_path = SPICEFilePath("imap_2025_v100.tm")
     assert file_path.spice_metadata["version"] == 100
     assert file_path.spice_metadata["type"] == "metakernel"
     assert file_path.spice_metadata["start_date"] == datetime(2025, 1, 1)
     assert len(file_path.spice_metadata) == 5
-    # Test attitude
+
+
+def test_spice_extract_attitude_parts():
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
     assert file_path.spice_metadata["version"] == 3
     assert file_path.spice_metadata["type"] == "attitude_history"
@@ -238,25 +242,39 @@ def test_spice_extract_parts():
         "2025_034", "%Y_%j"
     )
     assert len(file_path.spice_metadata) == 5
-    # Test leapsecond
+
+
+def test_spice_extract_leapsecond_parts():
     file_path = SPICEFilePath("naif0012.tls")
     assert file_path.spice_metadata["version"] == 12
     assert file_path.spice_metadata["type"] == "leapseconds"
     assert file_path.spice_metadata["extension"] == "tls"
+    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
+    assert file_path.spice_metadata["end_date"] == SPICEFilePath.LATEST_VALID_TIME
     assert len(file_path.spice_metadata) == 5
-    # Test planetary ephemeris
+
+
+def test_spice_extract_planetary_ephemeris_parts():
     file_path = SPICEFilePath("de440.bsp")
     assert file_path.spice_metadata["version"] == 440
     assert file_path.spice_metadata["type"] == "planetary_ephemeris"
     assert file_path.spice_metadata["extension"] == "bsp"
+    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
+    assert file_path.spice_metadata["end_date"] == SPICEFilePath.LATEST_VALID_TIME
     assert len(file_path.spice_metadata) == 5
-    # Test planetary constants
+
+
+def test_spice_extract_pck_parts():
     file_path = SPICEFilePath("pck00010.tpc")
     assert file_path.spice_metadata["version"] == 10
     assert file_path.spice_metadata["type"] == "planetary_constants"
     assert file_path.spice_metadata["extension"] == "tpc"
+    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
+    assert file_path.spice_metadata["end_date"] == SPICEFilePath.LATEST_VALID_TIME
     assert len(file_path.spice_metadata) == 5
-    # Test spacecraft ephemeris
+
+
+def test_spice_extract_ephemeris_parts():
     file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "ephemeris_90days"
@@ -268,10 +286,13 @@ def test_spice_extract_parts():
     )
     assert file_path.spice_metadata["extension"] == "bsp"
     assert len(file_path.spice_metadata) == 5
-    # Test repoint
+
+
+def test_spice_extract_repoint_parts():
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
+    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
     assert file_path.spice_metadata["end_date"] == datetime.strptime(
         "2025_230", "%Y_%j"
     )
@@ -297,7 +318,7 @@ def test_spice_extract_parts_static_method():
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_122_2025_122_01.spin.csv"
     )
-
+    assert file_parts["version"] == 1
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_032_2025_034_003.ah.bc",
     )

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -216,12 +216,19 @@ def test_spice_extract_parts():
     assert file_path.spice_metadata["type"] == "spin"
     assert file_path.spice_metadata["start_year_doy"] == "2025_122"
     assert file_path.spice_metadata["end_year_doy"] == "2025_122"
+    assert file_path.spice_metadata["start_date"] == datetime.strptime(
+        "2025_122", "%Y_%j"
+    )
+    assert file_path.spice_metadata["end_date"] == datetime.strptime(
+        "2025_122", "%Y_%j"
+    )
 
     # Test metakernel
     file_path = SPICEFilePath("imap_2025_v100.tm")
     assert file_path.spice_metadata["version"] == 100
     assert file_path.spice_metadata["type"] == "metakernel"
     assert file_path.spice_metadata["start_year"] == 2025
+    assert file_path.spice_metadata["start_date"] == datetime(2025, 1, 1)
 
     # Test attitude
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
@@ -229,6 +236,12 @@ def test_spice_extract_parts():
     assert file_path.spice_metadata["type"] == "attitude_history"
     assert file_path.spice_metadata["start_year_doy"] == "2025_032"
     assert file_path.spice_metadata["end_year_doy"] == "2025_034"
+    assert file_path.spice_metadata["start_date"] == datetime.strptime(
+        "2025_032", "%Y_%j"
+    )
+    assert file_path.spice_metadata["end_date"] == datetime.strptime(
+        "2025_034", "%Y_%j"
+    )
 
     # Test leapsecond
     file_path = SPICEFilePath("naif0012.tls")
@@ -265,6 +278,9 @@ def test_spice_extract_parts():
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
     assert file_path.spice_metadata["end_year_doy"] == "2025_230"
+    assert file_path.spice_metadata["end_date"] == datetime.strptime(
+        "2025_230", "%Y_%j"
+    )
 
 
 def test_spice_invalid_dates():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -178,9 +178,9 @@ def test_generate_from_inputs():
 
 def test_spice_file_path():
     """Tests the ``SPICEFilePath`` class."""
-    file_path = SPICEFilePath("imap_0000_000_0000_000_01.ap.bc")
+    file_path = SPICEFilePath("imap_1000_100_1000_100_01.ap.bc")
     assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/ck/imap_0000_000_0000_000_01.ap.bc"
+        "spice/ck/imap_1000_100_1000_100_01.ap.bc"
     )
 
     # Test a bad file extension too
@@ -198,14 +198,14 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("spice/repoint/imap_2025_122_01.repoint.csv")
 
-    metakernel_file = SPICEFilePath("imap_0000_v000.tm")
+    metakernel_file = SPICEFilePath("imap_1000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/mk/imap_0000_v000.tm")
+    ] / Path("spice/mk/imap_1000_v000.tm")
 
-    thruster_file = SPICEFilePath("imap_0000_000_hist_00.sff")
+    thruster_file = SPICEFilePath("imap_0001_001_hist_00.sff")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/activities/imap_0000_000_hist_00.sff"
+        "spice/activities/imap_0001_001_hist_00.sff"
     )
 
 
@@ -214,10 +214,8 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "spin"
-    assert file_path.spice_metadata["start_year"] == 2025
-    assert file_path.spice_metadata["end_year"] == 2025
-    assert file_path.spice_metadata["start_doy"] == 122
-    assert file_path.spice_metadata["end_doy"] == 122
+    assert file_path.spice_metadata["start_year_doy"] == "2025_122"
+    assert file_path.spice_metadata["end_year_doy"] == "2025_122"
 
     # Test metakernel
     file_path = SPICEFilePath("imap_2025_v100.tm")
@@ -229,10 +227,8 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
     assert file_path.spice_metadata["version"] == 3
     assert file_path.spice_metadata["type"] == "attitude_history"
-    assert file_path.spice_metadata["start_year"] == 2025
-    assert file_path.spice_metadata["end_year"] == 2025
-    assert file_path.spice_metadata["start_doy"] == 32
-    assert file_path.spice_metadata["end_doy"] == 34
+    assert file_path.spice_metadata["start_year_doy"] == "2025_032"
+    assert file_path.spice_metadata["end_year_doy"] == "2025_034"
 
     # Test leapsecond
     file_path = SPICEFilePath("naif0012.tls")
@@ -268,8 +264,7 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
-    assert file_path.spice_metadata["end_year"] == 2025
-    assert file_path.spice_metadata["end_doy"] == 230
+    assert file_path.spice_metadata["end_year_doy"] == "2025_230"
 
 
 def test_spice_invalid_dates():
@@ -297,10 +292,8 @@ def test_spice_extract_parts_static_method():
         "imap_2025_032_2025_034_003.ah.bc",
     )
     assert file_parts["mission"] == "imap"
-    assert file_parts["start_year"] == 2025
-    assert file_parts["start_doy"] == 32
-    assert file_parts["end_year"] == 2025
-    assert file_parts["end_doy"] == 34
+    assert file_parts["start_year_doy"] == "2025_032"
+    assert file_parts["end_year_doy"] == "2025_034"
     assert file_parts["version"] == 3
     assert file_parts["type"] == "attitude_history"
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -259,15 +259,6 @@ def test_spice_extract_parts_static_method():
 
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_032_2025_034_003.ah.bc",
-        parts=[
-            "mission",
-            "year_start",
-            "doy_start",
-            "year_end",
-            "doy_end",
-            "version",
-            "type",
-        ],
     )
     assert file_parts["mission"] == "imap"
     assert file_parts["year_start"] == "2025"

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -212,7 +212,7 @@ def test_spice_file_path():
 def test_spice_extract_spin_parts():
     # Test spin
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
-    assert file_path.spice_metadata["version"] == 1
+    assert file_path.spice_metadata["version"] == "01"
     assert file_path.spice_metadata["type"] == "spin"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_122", "%Y_%j"
@@ -225,7 +225,7 @@ def test_spice_extract_spin_parts():
 
 def test_spice_extract_metakernel_parts():
     file_path = SPICEFilePath("imap_2025_v100.tm")
-    assert file_path.spice_metadata["version"] == 100
+    assert file_path.spice_metadata["version"] == "100"
     assert file_path.spice_metadata["type"] == "metakernel"
     assert file_path.spice_metadata["start_date"] == datetime(2025, 1, 1)
     assert len(file_path.spice_metadata) == 5
@@ -233,7 +233,7 @@ def test_spice_extract_metakernel_parts():
 
 def test_spice_extract_attitude_parts():
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
-    assert file_path.spice_metadata["version"] == 3
+    assert file_path.spice_metadata["version"] == "003"
     assert file_path.spice_metadata["type"] == "attitude_history"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_032", "%Y_%j"
@@ -246,37 +246,47 @@ def test_spice_extract_attitude_parts():
 
 def test_spice_extract_leapsecond_parts():
     file_path = SPICEFilePath("naif0012.tls")
-    assert file_path.spice_metadata["version"] == 12
+    assert file_path.spice_metadata["version"] == "0012"
     assert file_path.spice_metadata["type"] == "leapseconds"
     assert file_path.spice_metadata["extension"] == "tls"
-    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
-    assert file_path.spice_metadata["end_date"] == SPICEFilePath.LATEST_VALID_TIME
+    assert file_path.spice_metadata["start_date"] is None
+    assert file_path.spice_metadata["end_date"] is None
+    assert len(file_path.spice_metadata) == 5
+
+
+def test_spice_extract_clock_parts():
+    file_path = SPICEFilePath("imapsclk_0012.tsc")
+    assert file_path.spice_metadata["version"] == "0012"
+    assert file_path.spice_metadata["type"] == "spacecraft_clock"
+    assert file_path.spice_metadata["extension"] == "tsc"
+    assert file_path.spice_metadata["start_date"] is None
+    assert file_path.spice_metadata["end_date"] is None
     assert len(file_path.spice_metadata) == 5
 
 
 def test_spice_extract_planetary_ephemeris_parts():
     file_path = SPICEFilePath("de440.bsp")
-    assert file_path.spice_metadata["version"] == 440
+    assert file_path.spice_metadata["version"] == "440"
     assert file_path.spice_metadata["type"] == "planetary_ephemeris"
     assert file_path.spice_metadata["extension"] == "bsp"
-    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
-    assert file_path.spice_metadata["end_date"] == SPICEFilePath.LATEST_VALID_TIME
+    assert file_path.spice_metadata["start_date"] is None
+    assert file_path.spice_metadata["end_date"] is None
     assert len(file_path.spice_metadata) == 5
 
 
 def test_spice_extract_pck_parts():
     file_path = SPICEFilePath("pck00010.tpc")
-    assert file_path.spice_metadata["version"] == 10
+    assert file_path.spice_metadata["version"] == "00010"
     assert file_path.spice_metadata["type"] == "planetary_constants"
     assert file_path.spice_metadata["extension"] == "tpc"
-    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
-    assert file_path.spice_metadata["end_date"] == SPICEFilePath.LATEST_VALID_TIME
+    assert file_path.spice_metadata["start_date"] is None
+    assert file_path.spice_metadata["end_date"] is None
     assert len(file_path.spice_metadata) == 5
 
 
 def test_spice_extract_ephemeris_parts():
     file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
-    assert file_path.spice_metadata["version"] == 1
+    assert file_path.spice_metadata["version"] == "01"
     assert file_path.spice_metadata["type"] == "ephemeris_90days"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "20251120", "%Y%m%d"
@@ -290,9 +300,9 @@ def test_spice_extract_ephemeris_parts():
 
 def test_spice_extract_repoint_parts():
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
-    assert file_path.spice_metadata["version"] == 1
+    assert file_path.spice_metadata["version"] == "01"
     assert file_path.spice_metadata["type"] == "repoint"
-    assert file_path.spice_metadata["start_date"] == SPICEFilePath.EARLIEST_VALID_TIME
+    assert file_path.spice_metadata["start_date"] is None
     assert file_path.spice_metadata["end_date"] == datetime.strptime(
         "2025_230", "%Y_%j"
     )
@@ -318,11 +328,11 @@ def test_spice_extract_parts_static_method():
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_122_2025_122_01.spin.csv"
     )
-    assert file_parts["version"] == 1
+    assert file_parts["version"] == "01"
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_032_2025_034_003.ah.bc",
     )
-    assert file_parts["version"] == 3
+    assert file_parts["version"] == "003"
     assert file_parts["type"] == "attitude_history"
 
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -1,5 +1,6 @@
 """Tests for the ``file_validataion`` module."""
 
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -213,25 +214,25 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "spin"
-    assert file_path.spice_metadata["start_year"] == "2025"
-    assert file_path.spice_metadata["end_year"] == "2025"
-    assert file_path.spice_metadata["start_doy"] == "122"
-    assert file_path.spice_metadata["end_doy"] == "122"
+    assert file_path.spice_metadata["start_year"] == 2025
+    assert file_path.spice_metadata["end_year"] == 2025
+    assert file_path.spice_metadata["start_doy"] == 122
+    assert file_path.spice_metadata["end_doy"] == 122
 
     # Test metakernel
     file_path = SPICEFilePath("imap_2025_v100.tm")
     assert file_path.spice_metadata["version"] == 100
     assert file_path.spice_metadata["type"] == "metakernel"
-    assert file_path.spice_metadata["start_year"] == "2025"
+    assert file_path.spice_metadata["start_year"] == 2025
 
     # Test attitude
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
     assert file_path.spice_metadata["version"] == 3
     assert file_path.spice_metadata["type"] == "attitude_history"
-    assert file_path.spice_metadata["start_year"] == "2025"
-    assert file_path.spice_metadata["end_year"] == "2025"
-    assert file_path.spice_metadata["start_doy"] == "032"
-    assert file_path.spice_metadata["end_doy"] == "034"
+    assert file_path.spice_metadata["start_year"] == 2025
+    assert file_path.spice_metadata["end_year"] == 2025
+    assert file_path.spice_metadata["start_doy"] == 32
+    assert file_path.spice_metadata["end_doy"] == 34
 
     # Test leapsecond
     file_path = SPICEFilePath("naif0012.tls")
@@ -255,16 +256,20 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "ephemeris_90days"
-    assert file_path.spice_metadata["start_date"] == "20251120"
-    assert file_path.spice_metadata["end_date"] == "20260220"
+    assert file_path.spice_metadata["start_date"] == datetime.strptime(
+        "20251120", "%Y%m%d"
+    )
+    assert file_path.spice_metadata["end_date"] == datetime.strptime(
+        "20260220", "%Y%m%d"
+    )
     assert file_path.spice_metadata["extension"] == "bsp"
 
     # Test repoint
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
-    assert file_path.spice_metadata["start_year"] == "2025"
-    assert file_path.spice_metadata["start_doy"] == "230"
+    assert file_path.spice_metadata["start_year"] == 2025
+    assert file_path.spice_metadata["start_doy"] == 230
 
 
 def test_spice_extract_parts_static_method():
@@ -278,10 +283,10 @@ def test_spice_extract_parts_static_method():
         "imap_2025_032_2025_034_003.ah.bc",
     )
     assert file_parts["mission"] == "imap"
-    assert file_parts["start_year"] == "2025"
-    assert file_parts["start_doy"] == "032"
-    assert file_parts["end_year"] == "2025"
-    assert file_parts["end_doy"] == "034"
+    assert file_parts["start_year"] == 2025
+    assert file_parts["start_doy"] == 32
+    assert file_parts["end_year"] == 2025
+    assert file_parts["end_doy"] == 34
     assert file_parts["version"] == 3
     assert file_parts["type"] == "attitude_history"
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -253,7 +253,7 @@ def test_spice_extract_parts():
 def test_spice_extract_parts_static_method():
     # Test spin
     file_parts = SPICEFilePath.extract_filename_components(
-        "imap_2025_122_2025_122_01.spin.csv", parts=["mission"]
+        "imap_2025_122_2025_122_01.spin.csv"
     )
     assert file_parts["mission"] == "imap"
 
@@ -261,10 +261,10 @@ def test_spice_extract_parts_static_method():
         "imap_2025_032_2025_034_003.ah.bc",
     )
     assert file_parts["mission"] == "imap"
-    assert file_parts["year_start"] == "2025"
-    assert file_parts["doy_start"] == "032"
-    assert file_parts["year_end"] == "2025"
-    assert file_parts["doy_end"] == "034"
+    assert file_parts["start_year"] == "2025"
+    assert file_parts["start_doy"] == "032"
+    assert file_parts["end_year"] == "2025"
+    assert file_parts["end_doy"] == "034"
     assert file_parts["version"] == 3
     assert file_parts["type"] == "attitude_history"
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -302,6 +302,7 @@ def test_spice_extract_repoint_parts():
     file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == "01"
     assert file_path.spice_metadata["type"] == "repoint"
+    assert file_path.spice_metadata["extension"] == "csv"
     assert file_path.spice_metadata["start_date"] is None
     assert file_path.spice_metadata["end_date"] == datetime.strptime(
         "2025_230", "%Y_%j"

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -250,6 +250,34 @@ def test_spice_extract_parts():
     assert file_path.spice_metadata["type"] == "repointing"
 
 
+def test_spice_extract_parts_static_method():
+    # Test spin
+    file_parts = SPICEFilePath.extract_filename_components(
+        "imap_2025_122_2025_122_01.spin.csv", parts=["mission"]
+    )
+    assert file_parts["mission"] == "imap"
+
+    file_parts = SPICEFilePath.extract_filename_components(
+        "imap_2025_032_2025_034_003.ah.bc",
+        parts=[
+            "mission",
+            "year_start",
+            "doy_start",
+            "year_end",
+            "doy_end",
+            "version",
+            "type",
+        ],
+    )
+    assert file_parts["mission"] == "imap"
+    assert file_parts["year_start"] == "2025"
+    assert file_parts["doy_start"] == "032"
+    assert file_parts["year_end"] == "2025"
+    assert file_parts["doy_end"] == "034"
+    assert file_parts["version"] == 3
+    assert file_parts["type"] == "attitude_history"
+
+
 def test_ancillary_file_path():
     """Tests the ``AncillaryFilePath`` class for different scenarios."""
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -192,10 +192,10 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("spice/spin/imap_2025_122_2025_122_01.spin.csv")
 
-    repoint_file_path = SPICEFilePath("imap_2025_122_2025_122_01.repoint.csv")
+    repoint_file_path = SPICEFilePath("imap_2025_122_01.repoint.csv")
     assert repoint_file_path.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/repoint/imap_2025_122_2025_122_01.repoint.csv")
+    ] / Path("spice/repoint/imap_2025_122_01.repoint.csv")
 
     metakernel_file = SPICEFilePath("imap_0000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
@@ -213,45 +213,62 @@ def test_spice_extract_parts():
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "spin"
+    assert file_path.spice_metadata["start_year"] == "2025"
+    assert file_path.spice_metadata["end_year"] == "2025"
+    assert file_path.spice_metadata["start_doy"] == "122"
+    assert file_path.spice_metadata["end_doy"] == "122"
 
     # Test metakernel
     file_path = SPICEFilePath("imap_2025_v100.tm")
     assert file_path.spice_metadata["version"] == 100
     assert file_path.spice_metadata["type"] == "metakernel"
+    assert file_path.spice_metadata["start_year"] == "2025"
 
     # Test attitude
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
     assert file_path.spice_metadata["version"] == 3
     assert file_path.spice_metadata["type"] == "attitude_history"
+    assert file_path.spice_metadata["start_year"] == "2025"
+    assert file_path.spice_metadata["end_year"] == "2025"
+    assert file_path.spice_metadata["start_doy"] == "032"
+    assert file_path.spice_metadata["end_doy"] == "034"
 
     # Test leapsecond
     file_path = SPICEFilePath("naif0012.tls")
     assert file_path.spice_metadata["version"] == 12
     assert file_path.spice_metadata["type"] == "leapseconds"
+    assert file_path.spice_metadata["extension"] == "tls"
 
     # Test planetary ephemeris
     file_path = SPICEFilePath("de440.bsp")
     assert file_path.spice_metadata["version"] == 440
     assert file_path.spice_metadata["type"] == "planetary_ephemeris"
+    assert file_path.spice_metadata["extension"] == "bsp"
 
     # Test planetary constants
     file_path = SPICEFilePath("pck00010.tpc")
     assert file_path.spice_metadata["version"] == 10
     assert file_path.spice_metadata["type"] == "planetary_constants"
+    assert file_path.spice_metadata["extension"] == "tpc"
 
     # Test spacecraft ephemeris
     file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "ephemeris_90days"
+    assert file_path.spice_metadata["start_date"] == "20251120"
+    assert file_path.spice_metadata["end_date"] == "20260220"
+    assert file_path.spice_metadata["extension"] == "bsp"
 
     # Test repoint
-    file_path = SPICEFilePath("imap_2025_230_2025_230_01.repoint.csv")
+    file_path = SPICEFilePath("imap_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
     assert file_path.spice_metadata["type"] == "repoint"
+    assert file_path.spice_metadata["start_year"] == "2025"
+    assert file_path.spice_metadata["start_doy"] == "230"
 
 
 def test_spice_extract_parts_static_method():
-    # Test spin
+    # Making sure the function works without an instance
     file_parts = SPICEFilePath.extract_filename_components(
         "imap_2025_122_2025_122_01.spin.csv"
     )

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -247,7 +247,7 @@ def test_spice_extract_parts():
     # Test repoint
     file_path = SPICEFilePath("imap_2025_230_2025_230_01.repoint.csv")
     assert file_path.spice_metadata["version"] == 1
-    assert file_path.spice_metadata["type"] == "repointing"
+    assert file_path.spice_metadata["type"] == "repoint"
 
 
 def test_spice_extract_parts_static_method():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -207,46 +207,47 @@ def test_spice_file_path():
         "spice/activities/imap_0000_000_hist_00.sff"
     )
 
+
 def test_spice_extract_parts():
     # Test spin
     file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
-    assert file_path.spice_metadata['version'] == 1
-    assert file_path.spice_metadata['type'] == 'spin'
+    assert file_path.spice_metadata["version"] == 1
+    assert file_path.spice_metadata["type"] == "spin"
 
     # Test metakernel
     file_path = SPICEFilePath("imap_2025_v100.tm")
-    assert file_path.spice_metadata['version'] == 100
-    assert file_path.spice_metadata['type'] == 'metakernel'
+    assert file_path.spice_metadata["version"] == 100
+    assert file_path.spice_metadata["type"] == "metakernel"
 
     # Test attitude
     file_path = SPICEFilePath("imap_2025_032_2025_034_003.ah.bc")
-    assert file_path.spice_metadata['version'] == 3
-    assert file_path.spice_metadata['type'] == 'attitude_history'
+    assert file_path.spice_metadata["version"] == 3
+    assert file_path.spice_metadata["type"] == "attitude_history"
 
     # Test leapsecond
     file_path = SPICEFilePath("naif0012.tls")
-    assert file_path.spice_metadata['version'] == 12
-    assert file_path.spice_metadata['type'] == 'leapseconds'
+    assert file_path.spice_metadata["version"] == 12
+    assert file_path.spice_metadata["type"] == "leapseconds"
 
     # Test planetary ephemeris
     file_path = SPICEFilePath("de440.bsp")
-    assert file_path.spice_metadata['version'] == 440
-    assert file_path.spice_metadata['type'] == 'planetary_ephemeris'
+    assert file_path.spice_metadata["version"] == 440
+    assert file_path.spice_metadata["type"] == "planetary_ephemeris"
 
     # Test planetary constants
     file_path = SPICEFilePath("pck00010.tpc")
-    assert file_path.spice_metadata['version'] == 10
-    assert file_path.spice_metadata['type'] == 'planetary_constants'
+    assert file_path.spice_metadata["version"] == 10
+    assert file_path.spice_metadata["type"] == "planetary_constants"
 
-    # Test spacecraft ephemeris 
+    # Test spacecraft ephemeris
     file_path = SPICEFilePath("imap_90days_20251120_20260220_v01.bsp")
-    assert file_path.spice_metadata['version'] == 1
-    assert file_path.spice_metadata['type'] == 'ephemeris_90days'
+    assert file_path.spice_metadata["version"] == 1
+    assert file_path.spice_metadata["type"] == "ephemeris_90days"
 
     # Test repoint
     file_path = SPICEFilePath("imap_2025_230_2025_230_01.repoint.csv")
-    assert file_path.spice_metadata['version'] == 1
-    assert file_path.spice_metadata['type'] == 'repointing'
+    assert file_path.spice_metadata["version"] == 1
+    assert file_path.spice_metadata["type"] == "repointing"
 
 
 def test_ancillary_file_path():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -272,6 +272,20 @@ def test_spice_extract_parts():
     assert file_path.spice_metadata["start_doy"] == 230
 
 
+def test_spice_invalid_dates():
+    # Ensure the DOY is valid (DOY 410??)
+    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+        file_path = SPICEFilePath("imap_2025_032_2025_410_003.ah.bc")
+
+    # Ensure dates are valid (Month 13??)
+    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+        file_path = SPICEFilePath("imap_90days_20251320_20260220_v01.bsp")
+
+    # Ensure valid ephemeris type (type taco??)
+    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+        file_path = SPICEFilePath("imap_taco_20251320_20260220_v01.bsp")
+
+
 def test_spice_extract_parts_static_method():
     # Making sure the function works without an instance
     file_parts = SPICEFilePath.extract_filename_components(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -104,7 +104,7 @@ def test_request_errors(mock_urlopen: unittest.mock.MagicMock):
         # Pathlib.Path object
         (Path(test_science_path), test_science_path),
         # SPICE file
-        ("imap_0000_000_0000_000_01.ap.bc", "spice/ck/imap_0000_000_0000_000_01.ap.bc"),
+        ("imap_1000_100_1000_100_01.ap.bc", "spice/ck/imap_1000_100_1000_100_01.ap.bc"),
     ],
 )
 def test_download(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -104,7 +104,7 @@ def test_request_errors(mock_urlopen: unittest.mock.MagicMock):
         # Pathlib.Path object
         (Path(test_science_path), test_science_path),
         # SPICE file
-        ("test.bc", "spice/ck/test.bc"),
+        ("imap_0000_000_0000_000_01.ap.bc", "spice/ck/imap_0000_000_0000_000_01.ap.bc"),
     ],
 )
 def test_download(

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -82,9 +82,9 @@ def test_create_ancillary_files():
 
 @pytest.mark.xfail(reason="SPICE not completed")
 def test_create_spice_files():
-    one_file = processing_input.SPICEInput("imap_0000_000_0000_000_01.ap.bc")
+    one_file = processing_input.SPICEInput("imap_1000_100_1000_100_01.ap.bc")
 
-    assert one_file.filename_list == ["imap_0000_000_0000_000_01.ap.bc"]
+    assert one_file.filename_list == ["imap_1000_100_1000_100_01.ap.bc"]
     assert len(one_file.imap_file_paths) == 1
     assert isinstance(one_file.imap_file_paths[0], SPICEFilePath)
     assert one_file.input_type == ProcessingInputType.SPICE_FILE

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -82,9 +82,9 @@ def test_create_ancillary_files():
 
 @pytest.mark.xfail(reason="SPICE not completed")
 def test_create_spice_files():
-    one_file = processing_input.SPICEInput("test.bc")
+    one_file = processing_input.SPICEInput("imap_0000_000_0000_000_01.ap.bc")
 
-    assert one_file.filename_list == ["test.bc"]
+    assert one_file.filename_list == ["imap_0000_000_0000_000_01.ap.bc"]
     assert len(one_file.imap_file_paths) == 1
     assert isinstance(one_file.imap_file_paths[0], SPICEFilePath)
     assert one_file.input_type == ProcessingInputType.SPICE_FILE


### PR DESCRIPTION
# Change Summary

## Overview
Adding in file name parsing for SPICE files

## New Dependencies
None

## New Files
None

## Deleted Files
None

## Updated Files
- imap_data_access/file_validation.py
   - Added more strict regex to the SPICE files 
   - Added an "extract" method that will return the spice type/version information
   - Added a new mapping dictionary to convert the types in the file names into something more readable
- tests/test_file_validation.py
   - Added unit tests to ensure the "extract_parts" method worked
   - Updated a few unit tests to use real SPICE file names
- tests/test_io.py
   - Updated a unit test to use real SPICE file names
- tests/test_processing_input.py
   - Updated a unit test to use real SPICE file names

## Testing
The tests already cover a large portion of the SPICEFilePath class, but I added tests to make sure we could extract file type/version information from all of the different SPICE files we could expect.