### PR TITLE
MNT: Allow for all files to be returned from input collection

### DIFF
--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -406,8 +406,6 @@ class ProcessingInputCollection:
             list of ScienceInput files contained in the collection.
         """
         out = []
-        if source is None and descriptor is None:
-            raise ValueError("At least source or descriptor must be provided.")
 
         for input_type in self.processing_input:
             matches_source = source is None or input_type.source == source
@@ -423,7 +421,5 @@ class ProcessingInputCollection:
         """Download all the dependencies for the processing input."""
         # Go through science or ancillary or SPICE dependencies
         # processing input list and download all files
-        for dependency in self.processing_input:
-            for filepath in dependency.imap_file_paths:
-                download_path = filepath.construct_path()
-                download(download_path)
+        for path in self.get_file_paths():
+            download(path)

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -393,6 +393,9 @@ class ProcessingInputCollection:
     ) -> list[Path]:
         """Get the dependency files path from the collection.
 
+        Returns all file paths if no source or descriptor is provided. Otherwise,
+        it returns only the files that match the source and/or descriptor.
+
         Parameters
         ----------
         source : str, optional

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -183,3 +183,31 @@ def test_get_file_paths():
 
     all_mag_files = input_collection.get_file_paths(descriptor="norm-magi")
     assert len(all_mag_files) == 2
+
+    all_files = input_collection.get_file_paths()
+    assert len(all_files) == 4
+
+
+# Add a test for download()
+def test_download_all_files(mock_urlopen):
+    # This example is fake example where we are processing HIT L2
+    # and it has three dependencies, one primary dependent (HIT l1b)
+    # and two ancillary dependents, MAG l1a and HIT ancillary.
+    mag_sci_anc = ScienceInput(
+        "imap_mag_l1a_norm-magi_20240312_v000.cdf",
+        "imap_mag_l1a_norm-magi_20240312_v001.cdf",
+    )
+    hit_anc = AncillaryInput(
+        "imap_hit_l1b-cal_20240312_v000.cdf",
+    )
+    hit_sci = ScienceInput(
+        "imap_hit_l1b_sci_20240312_v000.cdf",
+    )
+
+    input_collection = processing_input.ProcessingInputCollection(
+        mag_sci_anc, hit_anc, hit_sci
+    )
+    input_collection.download_all_files()
+    # Check that the files are downloaded
+    for file in input_collection.get_file_paths():
+        assert file.exists()


### PR DESCRIPTION
get_file_paths() would raise on both options being None, but we can simplify this to return all paths in that case, which can then be used in the download function to simplify that.