### PR TITLE
REL: Updating version for v0.16

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -31,8 +31,7 @@ __all__ = [
     "FILENAME_CONVENTION",
 ]
 
-__version__ = importlib.metadata.version("imap_data_access")
-
+__version__ = importlib.metadata.version("imap-data-access")
 
 config = {
     "DATA_ACCESS_URL": os.getenv("IMAP_DATA_ACCESS_URL")

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -5,6 +5,7 @@ heliosphere. This package contains the data access tools for the IMAP mission. I
 provides a convenient way to query the IMAP data archive and download data files.
 """
 
+import importlib.metadata
 import os
 from pathlib import Path
 
@@ -30,7 +31,7 @@ __all__ = [
     "FILENAME_CONVENTION",
 ]
 
-__version__ = "0.15.1"
+__version__ = importlib.metadata.version("imap_data_access")
 
 
 config = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imap-data-access"
-version = "0.15.1"
+version = "0.16.0"
 description = "IMAP SDC Data Access"
 authors = [{name = "IMAP SDC Developers", email = "imap-sdc@lists.lasp.colorado.edu"}]
 readme = "README.md"


### PR DESCRIPTION
* Bump the version number to 0.16
* Import the version number from the installed metadata rather than having to manually keep these in-sync