### PR TITLE
Adding Query by Ingestion date

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -355,7 +355,6 @@ def main():  # noqa: PLR0915
         type=str,
         required=False,
         help="Repointing number (repoint00000)",
-
     )
     query_parser.add_argument(
         "--version",

--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -57,6 +57,7 @@ def _print_query_results_table(query_results: list[dict]):
         "Data Level",
         "Descriptor",
         "Start Date",
+        "Ingestion Date",
         "Repointing",
         "Version",
         "Filename",
@@ -101,6 +102,7 @@ def _print_query_results_table(query_results: list[dict]):
             str(item.get("data_level", "")),
             str(item.get("descriptor", "")),
             str(item.get("start_date", "")),
+            str(item.get("ingestion_date", "")),
             str(item.get("repointing", "")) or "",
             str(item.get("version", "")),
             os.path.basename(item.get("file_path", "")),
@@ -126,6 +128,8 @@ def _query_parser(args: argparse.Namespace):
         "descriptor",
         "start_date",
         "end_date",
+        "ingestion_start_date",
+        "ingestion_end_date",
         "repointing",
         "version",
         "extension",
@@ -333,6 +337,18 @@ def main():  # noqa: PLR0915
         type=str,
         required=False,
         help="End date for a range of file timestamps in YYYYMMDD format",
+    )
+    query_parser.add_argument(
+        "--ingestion-start-date",
+        type=str,
+        required=False,
+        help="Ingestion start date by for files in YYYYMMDD format",
+    )
+    query_parser.add_argument(
+        "--ingestion-end-date",
+        type=str,
+        required=False,
+        help="Ingestion end date for a range of file timestamps in YYYYMMDD format",
     )
     query_parser.add_argument(
         "--repointing", type=int, required=False, help="Repointing number (int)"

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -108,6 +108,8 @@ def query(
     descriptor: Optional[str] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    ingestion_start_date: Optional[str] = None,
+    ingestion_end_date: Optional[str] = None,
     repointing: Optional[str] = None,
     version: Optional[str] = None,
     extension: Optional[str] = None,
@@ -133,6 +135,12 @@ def query(
     end_date : str, optional
         End date in YYYYMMDD format. Note this is to search for all files
         with start dates before the requested end_date.
+    ingestion_start_date : str, optional
+        Ingestion start date in YYYYMMDD format. Note this is to search
+        for all files with ingestion start dates on or after this value.
+    ingestion_end_date : str, optional
+        Ingestion end date in YYYYMMDD format. Note this is to search
+        for all files with ingestion start dates before the requested end_date.
     repointing : str, optional
         Repointing string, in the format 'repoint00000'
     version : str, optional
@@ -188,6 +196,20 @@ def query(
         end_date
     ):
         raise ValueError("Not a valid end date, use format 'YYYYMMDD'.")
+
+    # Check ingestion-start-date
+    if (
+        ingestion_start_date is not None
+        and not file_validation.ImapFilePath.is_valid_date(ingestion_start_date)
+    ):
+        raise ValueError("Not a valid ingestion start date, use format 'YYYYMMDD'.")
+
+    # Check ingestion-end-date
+    if (
+        ingestion_end_date is not None
+        and not file_validation.ImapFilePath.is_valid_date(ingestion_end_date)
+    ):
+        raise ValueError("Not a valid ingestion end date, use format 'YYYYMMDD'.")
 
     # Check version make sure to include 'latest'
     if version is not None and not file_validation.ImapFilePath.is_valid_version(

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -126,7 +126,7 @@ def query(
         Ingestion end date in YYYYMMDD format. Note this is to search
         for all files with ingestion start dates before the requested end_date.
     repointing : str, optional
-        Repointing string, in the format 'repoint00000'
+        Repointing string, in the format 'repoint00000'.
     version : str, optional
         Data version in the format ``vXXX`` or 'latest'.
     extension : str, optional

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -178,8 +178,8 @@ def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
             "descriptor": "test-description",
             "start_date": "20100101",
             "end_date": "20100102",
-            "ingestion_start_date": "20000101",  # Todo: Fill in
-            "ingestion_end_date": "20000102",  # Todo: Fill in
+            "ingestion_start_date": "20100101",
+            "ingestion_end_date": "20100102",
             "repointing": "repoint00001",
             "version": "v000",
             "extension": "pkts",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -178,8 +178,8 @@ def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
             "descriptor": "test-description",
             "start_date": "20100101",
             "end_date": "20100102",
-            "ingestion_start_date": "20100101",  # Todo: Fill in
-            "ingestion_end_date": "20100102",  # Todo: Fill in
+            "ingestion_start_date": "20000101",  # Todo: Fill in
+            "ingestion_end_date": "20000102",  # Todo: Fill in
             "repointing": "repoint00001",
             "version": "v000",
             "extension": "pkts",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -178,6 +178,8 @@ def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
             "descriptor": "test-description",
             "start_date": "20100101",
             "end_date": "20100102",
+            "ingestion_start_date": "",  # Todo: Fill in
+            "ingestion_end_date": "",  # Todo: Fill in
             "repointing": "repoint00001",
             "version": "v000",
             "extension": "pkts",
@@ -256,6 +258,16 @@ def test_query_bad_params(mock_urlopen: unittest.mock.MagicMock):
         ),
         ("start_date", "badInput", "Not a valid start date, use format 'YYYYMMDD'."),
         ("end_date", "badInput", "Not a valid end date, use format 'YYYYMMDD'."),
+        (
+            "ingestion_start_date",
+            "badInput",
+            "Not a valid ingestion start date, use format 'YYYYMMDD'.",
+        ),
+        (
+            "ingestion_end_date",
+            "badInput",
+            "Not a valid ingestion end date, use format 'YYYYMMDD'.",
+        ),
         (
             "repointing",
             "badInput",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -178,8 +178,8 @@ def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
             "descriptor": "test-description",
             "start_date": "20100101",
             "end_date": "20100102",
-            "ingestion_start_date": "",  # Todo: Fill in
-            "ingestion_end_date": "",  # Todo: Fill in
+            "ingestion_start_date": "20100101",  # Todo: Fill in
+            "ingestion_end_date": "20100102",  # Todo: Fill in
             "repointing": "repoint00001",
             "version": "v000",
             "extension": "pkts",


### PR DESCRIPTION
# Adding Ingestion start and end date Params

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Adding `ingestion_start_date` and `ingestion_end_date` to the `imap-data-access` API command line. 
Waiting for the `sds-data-manager ` side of the work to be merged and deployed first before I can fully test it. 

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->


## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- tests/test_io.py
- imap_data_access/cli.py
- imap_data_access/io.py

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
