### PR TITLE
MNT/FIX: Update SPICE sclk expected filename mapping

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -379,7 +379,7 @@ _SPICE_TYPE_MAPPING = {
     "de": "planetary_ephemeris",
     "pck": "planetary_constants",
     "naif": "leapseconds",
-    "imapsclk_": "spacecraft_clock",
+    "imap_sclk_": "spacecraft_clock",
     "tf": "frames",
     "tm": "metakernel",
     "sff": "thruster",
@@ -462,7 +462,7 @@ class SPICEFilePath(ImapFilePath):
     # Planetary Ephemeris (type: "de")
     # Planetary Constants (type: "pck")
     # Leapsecond kernel (type: "naif")
-    # Spacecraft clock kernel (type: "imapsclk_")
+    # Spacecraft clock kernel (type: "imap_sclk_")
     spice_prod_ver_pattern = (
         r"(?P<type>[a-zA-Z\-_]+)"
         r"(?P<version>[\d]+)\."

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -255,7 +255,7 @@ def test_spice_extract_leapsecond_parts():
 
 
 def test_spice_extract_clock_parts():
-    file_path = SPICEFilePath("imapsclk_0012.tsc")
+    file_path = SPICEFilePath("imap_sclk_0012.tsc")
     assert file_path.spice_metadata["version"] == "0012"
     assert file_path.spice_metadata["type"] == "spacecraft_clock"
     assert file_path.spice_metadata["extension"] == "tsc"


### PR DESCRIPTION
# Change Summary

## Overview

This updates the expected filename convention for the sclk kernel to use `imap_sclk_####.tsc` I updated the type-mapping portion rather than adding a new/different regex. Updating the regex directly caused naif and other filenames to fail. Not sure if this is the most robust approach or if others want another regex for this specifically.

closes #160