### PR TITLE
FIX: Webpoda downloads shouldn't be impacted by duplicate uploads

### DIFF
--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -23,7 +23,7 @@ import urllib.response
 from pathlib import Path
 
 import imap_data_access
-from imap_data_access.io import _get_url_response
+from imap_data_access.io import IMAPDataAccessError, _get_url_response
 
 logger = logging.getLogger(__name__)
 
@@ -337,7 +337,12 @@ def download_daily_data(
         path.write_bytes(daily_packet_content)
         if upload_to_server:
             # Upload the data to the server
-            imap_data_access.upload(path)
+            try:
+                imap_data_access.upload(path)
+            except IMAPDataAccessError as e:
+                # We don't want to ruin all subsequent downloads if one fails
+                # during upload, so log the error and continue
+                logger.error(f"Failed to upload {path} to the server: {e}")
 
 
 def download_repointing_data(  # noqa: PLR0913
@@ -481,4 +486,9 @@ def download_repointing_data(  # noqa: PLR0913
         path.write_bytes(pointing_packet_content)
         if upload_to_server:
             # Upload the data to the server
-            imap_data_access.upload(path)
+            try:
+                imap_data_access.upload(path)
+            except IMAPDataAccessError as e:
+                # We don't want to ruin all subsequent downloads if one fails
+                # during upload, so log the error and continue
+                logger.error(f"Failed to upload {path} to the server: {e}")

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -5,6 +5,7 @@ import pytest
 
 import imap_data_access
 from imap_data_access import ScienceFilePath
+from imap_data_access.io import IMAPDataAccessError
 from imap_data_access.webpoda import (
     INSTRUMENT_APIDS,
     _add_webpoda_headers,
@@ -69,6 +70,9 @@ def test_download_daily_data(
     mock_get_packet_binary_data_sctime,
     upload_to_server,
 ):
+    # We are mocking the upload, lets also verify that
+    # duplicate files don't propagate any errors.
+    mock_upload.side_effect = IMAPDataAccessError("File already exists")
     mock_get_packet_times_ert.return_value = [
         datetime.datetime(2024, 12, 1, 0, 0, 0),
         datetime.datetime(2024, 12, 2, 0, 0, 0),
@@ -110,6 +114,9 @@ def test_download_repointing_data(
     upload_to_server,
     tmpdir,
 ):
+    # We are mocking the upload, lets also verify that
+    # duplicate files don't propagate any errors.
+    mock_upload.side_effect = IMAPDataAccessError("File already exists")
     mock_get_packet_binary_data_sctime.return_value = b"\x00\x01\x02\x03"
     # Create a fake repointing file
     # We only use repoint_end_time_utc and repoint_id


### PR DESCRIPTION
# Change Summary

## Overview

When duplicate uploads occur to the IMAP SDC, we would throw an IMAPDataAccessError which would propagate up and stop all other download/uploads for other days of this instrument, or other instruments when used in a loop. We don't necessarily need to raise this error, but can rather just log it as an error and move on attempting all of the other days too.

Note that we have to do this within this inner loop if we get two days worth of data and one of them was duplicated but the other wasn't. There is no way to catch that in the outer instrument loop. Say 2025/04/03 was already present, and our webpoda client tries to create both 2025/04/03 and 2025/04/04 this next time.

This likely needs some additional future thought on how to address the duplicate versions (bump version automatically, something smarter, ...), but that could be slotted into this same code area later after discussions. This is an attempt to get things continuing on for now in our current automatic downloads.