### PR TITLE
Adding MOC metakernel to the list of expected kernels

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -486,8 +486,8 @@ class SPICEFilePath(ImapFilePath):
 
     # Covers:
     # SDC generated metakernels (type: 'tm')
-    mk_filename_pattern = (
-        r"(imap)_"
+    sdc_mk_filename_pattern = (
+        r"(imap)_sdc_metakernel_"
         r"(?P<start_year>[\d]{4})_"
         r"v(?P<version>[\d]{3})\."
         r"(?P<type>tm)"
@@ -515,7 +515,7 @@ class SPICEFilePath(ImapFilePath):
         re.compile(spice_prod_ver_pattern),
         re.compile(spice_frame_pattern),
         re.compile(sff_filename_pattern),
-        re.compile(mk_filename_pattern),
+        re.compile(sdc_mk_filename_pattern),
         re.compile(attitude_mk_filename_pattern),
         re.compile(ephemeris_mk_filename_pattern),
     )

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -368,6 +368,7 @@ class ScienceFilePath(ImapFilePath):
 _SPICE_TYPE_MAPPING = {
     "ah.bc": "attitude_history",
     "ap.bc": "attitude_predict",
+    "mk": "metakernel",
     "spin.csv": "spin",
     "repoint.csv": "repoint",
     "recon": "ephemeris_reconstructed",
@@ -484,12 +485,27 @@ class SPICEFilePath(ImapFilePath):
     )
 
     # Covers:
-    # Metakernels (type: 'tm')
+    # SDC generated metakernels (type: 'tm')
     mk_filename_pattern = (
         r"(imap)_"
         r"(?P<start_year>[\d]{4})_"
         r"v(?P<version>[\d]{3})\."
         r"(?P<type>tm)"
+    )
+
+    # Covers:
+    # MOC metakernels (type: 'mk')
+    attitude_mk_filename_pattern = (
+        r"imap_"
+        r"(?P<start_year_doy>\d{4}_\d{3})_"
+        r"a(?P<version>\d{2})\.spice\."
+        r"(?P<type>mk)"
+    )
+    ephemeris_mk_filename_pattern = (
+        r"IMAP_"
+        r"(?P<start_year_doy>\d{4}_\d{3})_"
+        r"e(?P<version>\d{2})\."
+        r"(?P<type>mk)"
     )
 
     valid_spice_regexes = (
@@ -500,6 +516,8 @@ class SPICEFilePath(ImapFilePath):
         re.compile(spice_frame_pattern),
         re.compile(sff_filename_pattern),
         re.compile(mk_filename_pattern),
+        re.compile(attitude_mk_filename_pattern),
+        re.compile(ephemeris_mk_filename_pattern),
     )
 
     class InvalidSPICEFileError(Exception):

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -368,7 +368,6 @@ class ScienceFilePath(ImapFilePath):
 _SPICE_TYPE_MAPPING = {
     "ah.bc": "attitude_history",
     "ap.bc": "attitude_predict",
-    "mk": "metakernel",
     "spin.csv": "spin",
     "repoint.csv": "repoint",
     "recon": "ephemeris_reconstructed",
@@ -382,6 +381,7 @@ _SPICE_TYPE_MAPPING = {
     "naif": "leapseconds",
     "imap_sclk_": "spacecraft_clock",
     "tf": "frames",
+    "mk": "metakernel",
     "tm": "metakernel",
     "sff": "thruster",
 }

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -641,7 +641,7 @@ class SPICEFilePath(ImapFilePath):
         """
         filename = Path(filename)
         for regex in SPICEFilePath.valid_spice_regexes:
-            m = regex.match(filename.name.lower())
+            m = regex.match(filename.name)
             if m is not None:
                 spice_metadata = SPICEFilePath._spice_parts_handler(m.groupdict())
                 # Add the extension to the metadata

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -208,6 +208,18 @@ def test_spice_file_path():
         "spice/activities/imap_0001_001_hist_00.sff"
     )
 
+    # MOC attitude and ephemeris metakernel files tests
+    moc_att_mk = SPICEFilePath("imap_2025_005_a01.spice.mk")
+    assert moc_att_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "spice/mk/imap_2025_005_a01.spice.mk"
+    )
+
+    # TODO: why is tests failing here?
+    moc_ephem_mk = SPICEFilePath("IMAP_2025_005_e01.mk")
+    assert moc_ephem_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "spice/mk/IMAP_2025_005_e01.mk"
+    )
+
 
 def test_spice_extract_spin_parts():
     # Test spin

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -198,10 +198,10 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("spice/repoint/imap_2025_122_01.repoint.csv")
 
-    metakernel_file = SPICEFilePath("imap_1000_v000.tm")
+    metakernel_file = SPICEFilePath("imap_sdc_metakernel_1000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/mk/imap_1000_v000.tm")
+    ] / Path("spice/mk/imap_sdc_metakernel_1000_v000.tm")
 
     thruster_file = SPICEFilePath("imap_0001_001_hist_00.sff")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
@@ -214,7 +214,6 @@ def test_spice_file_path():
         "spice/mk/imap_2025_005_a01.spice.mk"
     )
 
-    # TODO: why is tests failing here?
     moc_ephem_mk = SPICEFilePath("IMAP_2025_005_e01.mk")
     assert moc_ephem_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
         "spice/mk/IMAP_2025_005_e01.mk"
@@ -236,7 +235,7 @@ def test_spice_extract_spin_parts():
 
 
 def test_spice_extract_metakernel_parts():
-    file_path = SPICEFilePath("imap_2025_v100.tm")
+    file_path = SPICEFilePath("imap_sdc_metakernel_2025_v100.tm")
     assert file_path.spice_metadata["version"] == "100"
     assert file_path.spice_metadata["type"] == "metakernel"
     assert file_path.spice_metadata["start_date"] == datetime(2025, 1, 1)


### PR DESCRIPTION
# Change Summary

## Overview
Adding MOC attitude and ephemeris metakernel to the list.

## Updated Files
- imap_data_access/file_validation.py
   - changes to add it to the metakernels


## Testing
- tests/test_file_validation.py
