### PR TITLE
ENH: Add quicklook filepath

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -28,7 +28,6 @@ from imap_data_access.processing_input import (
 __all__ = [
     "FILENAME_CONVENTION",
     "VALID_DATALEVELS",
-    "VALID_FILE_EXTENSION",
     "VALID_INSTRUMENTS",
     "AncillaryFilePath",
     "AncillaryInput",
@@ -112,8 +111,6 @@ VALID_DATALEVELS = {
     "l3e",
 }
 
-VALID_FILE_EXTENSION = {"pkts", "cdf"}
-
 FILENAME_CONVENTION = (
     "<mission>_<instrument>_<datalevel>_<descriptor>_"
     "<startdate>(-<repointing>)_<version>.<extension>"
@@ -123,5 +120,3 @@ ANCILLARY_FILENAME_CONVENTION = (
     "<mission>_<instrument>_<description>_"
     "<start_date>(_<end_date>)_<version>.<extension>"
 )
-
-VALID_ANCILLARY_FILE_EXTENSION = {"cdf", "csv", "dat", "json", "zip"}

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -9,7 +9,7 @@ import requests
 
 import imap_data_access
 from imap_data_access import file_validation
-from imap_data_access.file_validation import generate_imap_file_path
+from imap_data_access.file_validation import ScienceFilePath, generate_imap_file_path
 
 logger = logging.getLogger(__name__)
 
@@ -217,8 +217,10 @@ def query(
         query_params["repointing"] = int(repointing[-5:])
 
     # check extension
-    if extension is not None and extension not in imap_data_access.VALID_FILE_EXTENSION:
-        raise ValueError("Not a valid extension, choose from ('pkts', 'cdf').")
+    if extension is not None and extension not in ScienceFilePath.VALID_EXTENSIONS:
+        raise ValueError(
+            f"Not a valid extension, choose from {ScienceFilePath.VALID_EXTENSIONS}."
+        )
 
     url = f"{imap_data_access.config['DATA_ACCESS_URL']}/query"
     request = requests.Request(method="GET", url=url, params=query_params).prepare()


### PR DESCRIPTION
# Change Summary

## Overview

This follows the same naming convention as Ancillary Files, but a different set of extensions and download location.

One thing of note is that we have `imap/instrument` for science files, `imap/ancillary/instrument` for ancillary files, and `spice/` for spice files (notice the lack of `imap/`). Do we want to bring ancillary/quicklook up a level to be more akin to spice? Bring spice into the `imap/` directory structure? Or it is all OK and not a big deal.