### PR TITLE
Add zip and dat as acceptable ancillary file extensions

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -108,4 +108,4 @@ ANCILLARY_FILENAME_CONVENTION = (
     "<start_date>(_<end_date>)_<version>.<extension>"
 )
 
-VALID_ANCILLARY_FILE_EXTENSION = {"cdf", "csv", "json", "zip", "dat"}
+VALID_ANCILLARY_FILE_EXTENSION = {"cdf", "csv", "dat", "json", "zip"}

--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -108,4 +108,4 @@ ANCILLARY_FILENAME_CONVENTION = (
     "<start_date>(_<end_date>)_<version>.<extension>"
 )
 
-VALID_ANCILLARY_FILE_EXTENSION = {"cdf", "csv", "json"}
+VALID_ANCILLARY_FILE_EXTENSION = {"cdf", "csv", "json", "zip", "dat"}


### PR DESCRIPTION
# Change Summary

## Overview
Adding zip and dat as acceptable file extensions for ancillary files. Closes #170.

## New Dependencies
N/A

## New Files
N/A

## Deleted Files
N/A

## Updated Files
- `imap_data_access/__init__.py`
   - Additional file extensions

## Testing
