### PR TITLE
DEP: Add certifi as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
+dependencies = ["certifi>=2017.4.17"]
 
 [project.scripts]
 imap-data-access = "imap_data_access.cli:main"


### PR DESCRIPTION
Many users have run into issues with certificate verifications. Lets add certifi as a dependency to match what requests does. This can be removed if we do switch over to requests in the future because requests already has this as a dependency.

Using the same versions as requests: https://github.com/psf/requests/blob/c4c8e20289ab82edad55d2fc07b42cbf08ae1441/setup.py#L40

Both the POC and Menlo are asking for this.