### PR TITLE
MNT: Add successful debug logs

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -96,6 +96,7 @@ def download(file_path: Union[Path, str]) -> Path:
         with open(destination, "wb") as local_file:
             local_file.write(response.read())
 
+    logger.debug("File %s downloaded successfully", destination)
     return destination
 
 
@@ -273,4 +274,10 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
             s3_url, data=local_file.read(), method="PUT", headers={"Content-Type": ""}
         )
         with _get_url_response(request) as response:
-            logger.debug("Received response: %s", response.read().decode("utf-8"))
+            logger.debug(
+                "Received status code [%s] with response: %s",
+                response.status,
+                response.read().decode("utf-8"),
+            )
+
+    logger.debug("File %s uploaded successfully", file_path)


### PR DESCRIPTION
# Change Summary

## Overview

The POC would like successful logs as well. We were returning "Received response:" with empty content before because we get a 200 response with no content in the body! This adds some nicer logs saying we were successful in downloading/uploading things, making them debug so they don't pollute things if people don't want verbose output.

ping @evbr1432