### PR TITLE
FIX: Repointing file timestamps don't have T in the UTC format

### DIFF
--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -418,7 +418,7 @@ def download_repointing_data(  # noqa: PLR0913
     #       assumed to be the shorter list (1/day vs 1000s of packets/day per apid)
     for i in range(len(repointings) - 1):
         pointing_start = datetime.datetime.strptime(
-            repointings[i]["repoint_end_utc"], "%Y-%m-%dT%H:%M:%S.%f"
+            repointings[i]["repoint_end_utc"], "%Y-%m-%d %H:%M:%S.%f"
         )
         if repointings[i + 1]["repoint_end_utc"].lower() == "nan":
             # Missing repointing end time, so it isn't a complete "pointing" yet.
@@ -435,7 +435,7 @@ def download_repointing_data(  # noqa: PLR0913
         #       The times included are [repointing_start, repointing_end), exclusive
         #       on the right edge
         pointing_end = datetime.datetime.strptime(
-            repointings[i + 1]["repoint_end_utc"], "%Y-%m-%dT%H:%M:%S.%f"
+            repointings[i + 1]["repoint_end_utc"], "%Y-%m-%d %H:%M:%S.%f"
         ) - datetime.timedelta(seconds=1)
         if pointing_end < packet_times[0]:
             # This pointing is before the first packet time, so skip it

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -128,9 +128,9 @@ def test_download_repointing_data(
             "repoint_start_utc,repoint_end_utc,"
             "repoint_id\n"
             # One packet per pointing period
-            "0,0,1,0,2024-11-30T00:00:00.000000,2024-11-30T20:15:00.000000,1\n"
-            "0,0,1,0,2024-12-01T00:00:00.000000,2024-12-01T00:15:00.000000,2\n"
-            "10,0,11,0,2024-12-02T00:00:00.000000,2024-12-02T00:15:00.000000,3\n"
+            "0,0,1,0,2024-11-30 00:00:00.000,2024-11-30 20:15:00.000,1\n"
+            "0,0,1,0,2024-12-01 00:00:00.000,2024-12-01 00:15:00.000,2\n"
+            "10,0,11,0,2024-12-02 00:00:00.000,2024-12-02 00:15:00.000,3\n"
             # An unfinished repointing maneuver may have NaNs in the end times
             # Make sure we can handle this and ignore it
             "10,0,NaN,NaN,2024-12-03T00:00:00.000000,NaN,4\n"


### PR DESCRIPTION
Remove the T and change it to a space.

Found this while trying to download the repointing data locally using the latest version in our s3 bucket.