### PR TITLE
REL: Version bump to 0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imap-data-access"
-version = "0.18.2"
+version = "0.19.0"
 description = "IMAP SDC Data Access"
 authors = [{name = "IMAP SDC Developers", email = "imap-sdc@lists.lasp.colorado.edu"}]
 readme = "README.md"


### PR DESCRIPTION
# Change Summary

## Overview

There have been a few clarger changes like adding a dependency (certifi), so lets do a minor version bump.

Waiting on https://github.com/IMAP-Science-Operations-Center/imap-data-access/pull/178 before actually releasing.