### PR TITLE
ENH: Switch over to requests for I/O

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -1,13 +1,11 @@
 """Input/output capabilities for the IMAP data processing pipeline."""
 
 import contextlib
-import json
 import logging
-import urllib.request
 from pathlib import Path
 from typing import Optional, Union
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+
+import requests
 
 import imap_data_access
 from imap_data_access import file_validation
@@ -23,33 +21,25 @@ class IMAPDataAccessError(Exception):
 
 
 @contextlib.contextmanager
-def _get_url_response(request: urllib.request.Request):
-    """Get the response from a URL request.
+def _make_request(request: requests.PreparedRequest):
+    """Get the response from a URL request using the requests library.
 
-    This is a helper function to make it easier to handle
-    the different types of errors that can occur when
-    opening a URL and write out the response body.
+    This is a helper function to handle different types of errors that can occur
+    when making HTTP requests and yield the response body.
     """
     try:
-        # Open the URL and yield the response
-        with urllib.request.urlopen(request) as response:
+        with requests.Session() as session:
+            response = session.send(request)
+            response.raise_for_status()
             yield response
-
-    except HTTPError as e:
-        if e.status == 307:
-            # If the server is redirecting us, we need to follow the redirect
-            request.full_url = e.headers["Location"]
-            with _get_url_response(request) as response:
-                yield response
-        else:
-            message = (
-                f"HTTP Error: {e.code} - {e.reason}\n"
-                f"Server Message: {e.read().decode('utf-8')}"
-            )
-            raise IMAPDataAccessError(message) from e
-
-    except URLError as e:
-        message = f"URL Error: {e.reason}"
+    except requests.exceptions.HTTPError as e:
+        message = (
+            f"HTTP Error: {e.response.status_code} - {e.response.reason}\n"
+            f"Server Message: {e.response.text}"
+        )
+        raise IMAPDataAccessError(message) from e
+    except requests.exceptions.RequestException as e:
+        message = f"Request Error: {e}"
         raise IMAPDataAccessError(message) from e
 
 
@@ -81,20 +71,17 @@ def download(file_path: Union[Path, str]) -> Path:
         logger.info("The file %s already exists, skipping download", destination)
         return destination
 
-    # encode the query parameters
-    url = f"{imap_data_access.config['DATA_ACCESS_URL']}"
-    url += f"/download/{file_path}"
+    url = f"{imap_data_access.config['DATA_ACCESS_URL']}/download/{file_path}"
     logger.info("Downloading file %s from %s to %s", file_path, url, destination)
 
     # Create a request with the provided URL
-    request = urllib.request.Request(url, method="GET")
+    request = requests.Request("GET", url).prepare()
     # Open the URL and download the file
-    with _get_url_response(request) as response:
+    with _make_request(request) as response:
         logger.debug("Received response: %s", response)
         # Save the file locally with the same filename
         destination.parent.mkdir(parents=True, exist_ok=True)
-        with open(destination, "wb") as local_file:
-            local_file.write(response.read())
+        destination.write_bytes(response.content)
 
     logger.debug("File %s downloaded successfully", destination)
     return destination
@@ -210,17 +197,15 @@ def query(
     if extension is not None and extension not in imap_data_access.VALID_FILE_EXTENSION:
         raise ValueError("Not a valid extension, choose from ('pkts', 'cdf').")
 
-    url = f"{imap_data_access.config['DATA_ACCESS_URL']}"
-    url += f"/query?{urlencode(query_params)}"
+    url = f"{imap_data_access.config['DATA_ACCESS_URL']}/query"
+    request = requests.Request(method="GET", url=url, params=query_params).prepare()
 
-    logger.info("Querying data archive for %s with url %s", query_params, url)
-    request = urllib.request.Request(url, method="GET")
-    with _get_url_response(request) as response:
+    logger.info("Querying data archive for %s with url %s", query_params, request.url)
+    with _make_request(request) as response:
         # Retrieve the response as a list of files
-        items = response.read().decode("utf-8")
-        logger.debug("Received response: %s", items)
+        logger.debug("Received response: %s", response.text)
         # Decode the JSON string into a list
-        items = json.loads(items)
+        items = response.json()
         logger.debug("Decoded JSON: %s", items)
 
     # if latest version was included in search then filter returned query for largest.
@@ -249,35 +234,32 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
     if not file_path.exists():
         raise FileNotFoundError(file_path)
 
-    url = f"{imap_data_access.config['DATA_ACCESS_URL']}"
     # The upload name needs to be given as a path parameter
-    url += f"/upload/{file_path.name}"
+    url = f"{imap_data_access.config['DATA_ACCESS_URL']}/upload/{file_path.name}"
     logger.info("Uploading file %s to %s", file_path, url)
 
     # Create a request header with the API key
     api_key = api_key or imap_data_access.config["API_KEY"]
+
     # We send a GET request with the filename and the server
     # will respond with an s3 presigned URL that we can use
     # to upload the file to the data archive
     headers = {"X-api-key": api_key} if api_key else {}
-    request = urllib.request.Request(url, method="GET", headers=headers)
+    request = requests.Request("GET", url, headers=headers).prepare()
 
-    with _get_url_response(request) as response:
-        # Retrieve the key for the upload
-        s3_url = response.read().decode("utf-8")
+    with _make_request(request) as response:
+        s3_url = response.json()
         logger.debug("Received s3 presigned URL: %s", s3_url)
-        s3_url = json.loads(s3_url)
 
     # Follow the presigned URL to upload the file with a PUT request
-    with open(file_path, "rb") as local_file:
-        request = urllib.request.Request(
-            s3_url, data=local_file.read(), method="PUT", headers={"Content-Type": ""}
+    upload_request = requests.Request(
+        "PUT", s3_url, data=file_path.read_bytes(), headers={"Content-Type": ""}
+    ).prepare()
+    with _make_request(upload_request) as response:
+        logger.debug(
+            "Received status code [%s] with response: %s",
+            response.status_code,
+            response.text,
         )
-        with _get_url_response(request) as response:
-            logger.debug(
-                "Received status code [%s] with response: %s",
-                response.status,
-                response.read().decode("utf-8"),
-            )
 
     logger.debug("File %s uploaded successfully", file_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dependencies = ["certifi>=2017.4.17"]
+dependencies = ["requests>=2.29"]
 
 [project.scripts]
 imap-data-access = "imap_data_access.cli:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,17 +19,29 @@ def _set_global_config(monkeypatch: pytest.fixture, tmp_path: pytest.fixture):
     monkeypatch.setitem(imap_data_access.config, "WEBPODA_TOKEN", "test_token")
 
 
-@pytest.fixture
-def mock_urlopen():
-    """Mock urlopen to return a file-like object.
+@pytest.fixture(autouse=True)
+def mock_send_request():
+    """Mock session to return a requests-like object.
 
     Yields
     ------
-    mock_urlopen : unittest.mock.MagicMock
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``session.send()``
+    """
+    with patch("requests.Session") as mock_session:
+        mock_session_instance = mock_session.return_value.__enter__.return_value
+        mock_session_instance.send.return_value.content = b"Mock file content"
+        yield mock_session_instance.send
+
+
+@pytest.fixture
+def mock_request():
+    """Mock request to return a requests-like object.
+
+    Yields
+    ------
+    mock_request : unittest.mock.MagicMock
         Mock object for ``urlopen``
     """
-    mock_data = b"Mock file content"
-    with patch("urllib.request.urlopen") as mock_urlopen:
-        mock_response = mock_urlopen.return_value.__enter__.return_value
-        mock_response.read.return_value = mock_data
-        yield mock_urlopen
+    with patch("requests.Request") as mock_request:
+        yield mock_request

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,92 +2,62 @@
 
 from __future__ import annotations
 
-import json
 import os
-import re
-import unittest
-from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request
+from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 import imap_data_access
-from imap_data_access.io import _get_url_response
+from imap_data_access.io import _make_request
 
 test_science_filename = "imap_swe_l1_test-description_20100101_v000.cdf"
 test_science_path = "imap/swe/l1/2010/01/" + test_science_filename
 
 
-def _set_mock_data(mock_urlopen: unittest.mock.MagicMock, data: bytes):
-    """Set the data returned by the mock urlopen.
-
-    Parameters
-    ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    data : bytes
-        The mock data
-    """
-    mock_response = mock_urlopen.return_value.__enter__.return_value
-    mock_response.read.return_value = data
-
-
-@patch("urllib.request.urlopen")
-def test_redirect_followed(mock_urlopen):
+def test_redirect(mock_send_request):
     """Verify that we follow a 307 redirect from newly created s3 buckets.
 
-    Fairly involved mocking of urlopen, but we need to add two responses to
-    the urlopen mock. The first response is a 307 redirect, which we need to
-    follow to get the final response. The second response is our good return.
-    Then verify that our second response was actually followed in the request
-    arguments.
+    Since we are mocking here, we just need to make sure that we are getting
+    back the correct response and it doesn't raise for status. We could probably
+    use mock_requests here to do something fancier in the future.
     """
     # Mocking the first response (307 Redirect)
-    # Mock the first call to raise a 307 HTTPError
-    mock_error_response = HTTPError(
-        url="http://test-example.com",
-        code=307,
-        msg="Temporary Redirect",
-        hdrs={"Location": "http://followed-redirect.com"},
-        fp=None,
-    )
-
-    # Mocking the second response (200 OK)
-    mock_success_response = MagicMock()
-    mock_success_response.__enter__.return_value.getcode.return_value = 200
+    mock_redirect_response = MagicMock()
+    mock_redirect_response.status_code = 307
+    mock_redirect_response.headers = {"Location": "http://followed-redirect.com"}
 
     # Using side_effect to alternate between 307 and 200 responses
-    mock_urlopen.side_effect = [mock_error_response, mock_success_response]
+    mock_send_request.return_value = mock_redirect_response
 
-    with _get_url_response(Request("http://test-example.com")) as response:
-        assert mock_urlopen.call_count == 2
-        assert response.getcode() == 200
-        second_call_args = mock_urlopen.call_args_list[1]
-        assert second_call_args[0][0].full_url == "http://followed-redirect.com"
+    request = MagicMock()
+    request.url = "http://test-example.com"
+    with _make_request(request) as response:
+        assert mock_send_request.call_count == 1
+        assert response.status_code == 307
 
 
-def test_request_errors(mock_urlopen: unittest.mock.MagicMock):
-    """Test that invalid URLs raise an appropriate HTTPError or URLError.
+def test_request_errors(mock_send_request):
+    """Test that invalid URLs raise an appropriate HTTPError or RequestException.
 
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for requests.Session
     """
     # Set up the mock to raise an HTTPError
-    mock_urlopen.side_effect = HTTPError(
-        url="http://example.com", code=404, msg="Not Found", hdrs={}, fp=BytesIO()
+    mock_send_request.side_effect = requests.exceptions.HTTPError(
+        response=MagicMock(status_code=404, reason="Not Found")
     )
     with pytest.raises(imap_data_access.io.IMAPDataAccessError, match="HTTP Error"):
         imap_data_access.download(test_science_path)
 
-    # Set up the mock to raise a URLError
-    mock_urlopen.side_effect = URLError(reason="Not Found")
-    with pytest.raises(imap_data_access.io.IMAPDataAccessError, match="URL Error"):
+    # Set up the mock to raise a RequestException
+    mock_send_request.side_effect = requests.exceptions.RequestException(
+        "Request failed"
+    )
+    with pytest.raises(imap_data_access.io.IMAPDataAccessError, match="Request Error"):
         imap_data_access.download(test_science_path)
 
 
@@ -107,20 +77,24 @@ def test_request_errors(mock_urlopen: unittest.mock.MagicMock):
         ("imap_1000_100_1000_100_01.ap.bc", "spice/ck/imap_1000_100_1000_100_01.ap.bc"),
     ],
 )
-def test_download(
-    mock_urlopen: unittest.mock.MagicMock, file_path: str | Path, destination: str
-):
+def test_download(mock_send_request, file_path: str | Path, destination: str):
     """Test that the download API works as expected.
 
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for requests.Session
     file_path : str or Path
         The path to the file to download
     destination : str
         The path to which the file is expected to be downloaded
     """
+    # Mock the response to return binary content
+    mock_response = MagicMock()
+    mock_response.content = b"Mock file content"
+    mock_response.status_code = 200
+    mock_send_request.return_value = mock_response
+
     # Call the download function
     result = imap_data_access.download(file_path)
 
@@ -131,31 +105,26 @@ def test_download(
     assert result == expected_destination
 
     # Assert that the file content matches the mock data
-    with open(result, "rb") as f:
-        assert f.read() == b"Mock file content"
+    assert result.read_bytes() == b"Mock file content"
 
-    # Should have only been one call to urlopen
-    mock_urlopen.assert_called_once()
+    # Should have only been one call to send
+    mock_send_request.assert_called_once()
 
     # Assert that the correct URL was used for the download
-    urlopen_calls = mock_urlopen.mock_calls
-    # Check the arguments passed to urlopen
-    # We pass a Request object, so need to get that with args[0]
-    request_sent = urlopen_calls[0].args[0]
-    called_url = request_sent.full_url
-    # url should be provided as path parameters
+    sent_request = mock_send_request.call_args[0][0]
+    called_url = sent_request.url
     expected_url_encoded = f"https://api.test.com/download/{destination}"
     assert called_url == expected_url_encoded
-    assert request_sent.method == "GET"
+    assert sent_request.method == "GET"
 
 
-def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
-    """Test that downloading a file that already exists does result in any requests.
+def test_download_already_exists(mock_send_request):
+    """Test that downloading a file that already exists does not result in any requests.
 
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for requests.Session
     """
     # Call the download function
     # set up the destination and create a file
@@ -165,7 +134,7 @@ def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
     result = imap_data_access.download(test_science_path)
     assert result == destination
     # Make sure we didn't make any requests
-    assert mock_urlopen.call_count == 0
+    assert mock_send_request.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -186,56 +155,58 @@ def test_download_already_exists(mock_urlopen: unittest.mock.MagicMock):
         {"instrument": "swe", "data_level": "l0"},
     ],
 )
-def test_query(mock_urlopen: unittest.mock.MagicMock, query_params: list[dict]):
+def test_query(mock_send_request, query_params: dict):
     """Test a basic call to the Query API.
 
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    query_params : list of dict
-        A list of key/value pairs that set the query parameters
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for requests.Session
+    query_params : dict
+        Dictionary of key/value pairs that set the query parameters
     """
-    _set_mock_data(mock_urlopen, json.dumps([]).encode("utf-8"))
+    mock_response = MagicMock()
+    mock_response.json.return_value = []
+    mock_send_request.return_value = mock_response
+
     response = imap_data_access.query(**query_params)
     # No data found, and JSON decoding works as expected
     assert response == list()
 
-    # Should have only been one call to urlopen
-    mock_urlopen.assert_called_once()
+    # Should have only been one call to send
+    mock_send_request.assert_called_once()
     # Assert that the correct URL was used for the query
-    urlopen_call = mock_urlopen.mock_calls[0].args[0]
-    called_url = urlopen_call.full_url
-    expected_url_encoded = f"https://api.test.com/query?{urlencode(query_params)}"
+    sent_request = mock_send_request.call_args[0][0]
+    called_url = sent_request.url
+    str_params = "&".join(f"{k}={v}" for k, v in query_params.items())
+    expected_url_encoded = f"https://api.test.com/query?{str_params}"
     assert called_url == expected_url_encoded
 
 
-def test_query_no_params(mock_urlopen: unittest.mock.MagicMock):
+def test_query_no_params(mock_send_request):
     """Test a call to the Query API that has no parameters.
-
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``requests.session``
     """
     with pytest.raises(ValueError, match="At least one query"):
         imap_data_access.query()
     # Should not have made any calls to urlopen
-    assert mock_urlopen.call_count == 0
+    assert mock_send_request.call_count == 0
 
 
-def test_query_bad_params(mock_urlopen: unittest.mock.MagicMock):
+def test_query_bad_params(mock_send_request):
     """Test a call to the Query API that has invalid parameters.
-
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``requests.session``
     """
     with pytest.raises(TypeError, match="got an unexpected"):
         imap_data_access.query(bad_param="test")
     # Should not have made any calls to urlopen
-    assert mock_urlopen.call_count == 0
+    assert mock_send_request.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -266,15 +237,13 @@ def test_query_bad_params(mock_urlopen: unittest.mock.MagicMock):
         (
             "extension",
             "badInput",
-            re.escape("Not a valid extension, choose from ('pkts', 'cdf')."),
+            "Not a valid extension, choose from",
         ),
     ],
 )
 def test_bad_query_input(query_flag, query_input, expected_output):
     """Test a function call to query with correct params but bad values.
-
      Ensures correct error message is returned.
-
     Parameters
     ----------
     query_flag : str
@@ -291,20 +260,19 @@ def test_bad_query_input(query_flag, query_input, expected_output):
         imap_data_access.query(**kwargs)
 
 
-def test_upload_no_file(mock_urlopen: unittest.mock.MagicMock):
+def test_upload_no_file(mock_send_request):
     """Test a call to the upload API that has no filename supplied.
-
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``requests.session``
     """
     path = Path("/non-existant/file.txt")
     assert not path.exists()
     with pytest.raises(FileNotFoundError):
         imap_data_access.upload(path)
     # Should not have made any calls to urlopen
-    assert mock_urlopen.call_count == 0
+    assert mock_send_request.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -315,18 +283,17 @@ def test_upload_no_file(mock_urlopen: unittest.mock.MagicMock):
     [(None, {}), ("test-api-key", {"X-api-key": "test-api-key"})],
 )
 def test_upload(
-    mock_urlopen: unittest.mock.MagicMock,
+    mock_send_request,
     upload_file_path: str | Path,
     api_key: str | None,
     expected_header: dict,
     monkeypatch,
 ):
     """Test a basic call to the upload API.
-
     Parameters
     ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``requests.session``
     upload_file_path : str or Path
         The upload file path to test with
     api_key : str or None
@@ -335,47 +302,44 @@ def test_upload(
         The expected header to be sent with the request
     """
     monkeypatch.setitem(imap_data_access.config, "API_KEY", None)
-    _set_mock_data(mock_urlopen, b'"https://s3-test-bucket.com"')
+    mock_send_request.return_value.json.return_value = "https://s3-test-bucket.com"
     # Call the upload function
     file_to_upload = imap_data_access.config["DATA_DIR"] / upload_file_path
     file_to_upload.parent.mkdir(parents=True, exist_ok=True)
-    with open(file_to_upload, "wb") as f:
-        f.write(b"test file content")
-    assert file_to_upload.exists()
+    file_to_upload.write_bytes(b"test file content")
 
     os.chdir(imap_data_access.config["DATA_DIR"])
     imap_data_access.upload(upload_file_path, api_key=api_key)
 
-    # Should have been two calls to urlopen
+    # Should have been two calls to make a request
     # 1. To get the s3 upload url
     # 2. To upload the file to the url returned in 1.
-    assert mock_urlopen.call_count == 2
+    assert mock_send_request.call_count == 2
 
     # We get all returned calls, but we only need the calls
     # where we sent requests
     mock_calls = [
         call
-        for call in mock_urlopen.mock_calls
-        if len(call.args) and isinstance(call.args[0], Request)
+        for call in mock_send_request.mock_calls
+        if len(call.args) and isinstance(call.args[0], requests.PreparedRequest)
     ]
 
     # First urlopen call should be to get the s3 upload url
-    urlopen_call = mock_calls[0]
-    request_sent = urlopen_call.args[0]
-    called_url = request_sent.full_url
+    request_sent = mock_calls[0].args[0]
+    called_url = request_sent.url
     expected_url_encoded = "https://api.test.com/upload/test-file.txt"
     assert called_url == expected_url_encoded
     assert request_sent.method == "GET"
     # An API key needs to be added to the header for uploads
     assert request_sent.headers == expected_header
 
+    print(mock_calls)
     # Verify that we put that response into our second request
-    urlopen_call = mock_calls[1]
-    request_sent = urlopen_call.args[0]
-    called_url = request_sent.full_url
-    expected_url_encoded = "https://s3-test-bucket.com"
+    request_sent = mock_calls[1].args[0]
+    called_url = request_sent.url
+    expected_url_encoded = "https://s3-test-bucket.com/"
     assert called_url == expected_url_encoded
     assert request_sent.method == "PUT"
 
     # Assert that the original data from the test file was sent
-    assert request_sent.data == b"test file content"
+    assert request_sent.body == b"test file content"

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -189,7 +189,7 @@ def test_get_file_paths():
 
 
 # Add a test for download()
-def test_download_all_files(mock_urlopen):
+def test_download_all_files():
     # This example is fake example where we are processing HIT L2
     # and it has three dependencies, one primary dependent (HIT l1b)
     # and two ancillary dependents, MAG l1a and HIT ancillary.


### PR DESCRIPTION
# Change Summary

## Overview

External users have issues with certificate verification, so to make things easier on them we can use the requests library instead of the standard library. This also simplifies some of our handling of redirects and query parameter encoding as those come along for free with requests.

I've tested the download/upload/query/webpoda cli and all appear to be working as I'd expect still.

closes #106

## New Dependencies

requests

## Testing

Note that I spent some time trying to figure out how to mock a 307 response to follow a redirect, but since requests automatically handles that for us I couldn't get something to work that wasn't just testing my mock implementation. Happy for suggestions if there are any, but otherwise our critical piece is just that we don't raise on a 307 which we did previously and we don't here in the test either.

