### PR TITLE
MNT: Update spice directory to be under `imap/` like others

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -555,7 +555,7 @@ class SPICEFilePath(ImapFilePath):
         Path
             Upload path
         """
-        spice_dir = imap_data_access.config["DATA_DIR"] / "spice"
+        spice_dir = imap_data_access.config["DATA_DIR"] / "imap/spice"
         subdir = _SPICE_DIR_MAPPING[self.spice_metadata["type"]]
         # Use the file suffix to determine the directory structure
         # IMAP_DATA_DIR/spice/<subdir>/filename

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -180,7 +180,7 @@ def test_spice_file_path():
     """Tests the ``SPICEFilePath`` class."""
     file_path = SPICEFilePath("imap_1000_100_1000_100_01.ap.bc")
     assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/ck/imap_1000_100_1000_100_01.ap.bc"
+        "imap/spice/ck/imap_1000_100_1000_100_01.ap.bc"
     )
 
     # Test a bad file extension too
@@ -191,32 +191,32 @@ def test_spice_file_path():
     spin_file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
     assert spin_file_path.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/spin/imap_2025_122_2025_122_01.spin.csv")
+    ] / Path("imap/spice/spin/imap_2025_122_2025_122_01.spin.csv")
 
     repoint_file_path = SPICEFilePath("imap_2025_122_01.repoint.csv")
     assert repoint_file_path.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/repoint/imap_2025_122_01.repoint.csv")
+    ] / Path("imap/spice/repoint/imap_2025_122_01.repoint.csv")
 
     metakernel_file = SPICEFilePath("imap_sdc_metakernel_1000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("spice/mk/imap_sdc_metakernel_1000_v000.tm")
+    ] / Path("imap/spice/mk/imap_sdc_metakernel_1000_v000.tm")
 
     thruster_file = SPICEFilePath("imap_0001_001_hist_00.sff")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/activities/imap_0001_001_hist_00.sff"
+        "imap/spice/activities/imap_0001_001_hist_00.sff"
     )
 
     # MOC attitude and ephemeris metakernel files tests
     moc_att_mk = SPICEFilePath("imap_2025_005_a01.spice.mk")
     assert moc_att_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/mk/imap_2025_005_a01.spice.mk"
+        "imap/spice/mk/imap_2025_005_a01.spice.mk"
     )
 
     moc_ephem_mk = SPICEFilePath("IMAP_2025_005_e01.mk")
     assert moc_ephem_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "spice/mk/IMAP_2025_005_e01.mk"
+        "imap/spice/mk/IMAP_2025_005_e01.mk"
     )
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -72,7 +72,10 @@ def test_request_errors(mock_send_request):
         # Pathlib.Path object
         (Path(test_science_path), test_science_path),
         # SPICE file
-        ("imap_1000_100_1000_100_01.ap.bc", "spice/ck/imap_1000_100_1000_100_01.ap.bc"),
+        (
+            "imap_1000_100_1000_100_01.ap.bc",
+            "imap/spice/ck/imap_1000_100_1000_100_01.ap.bc",
+        ),
     ],
 )
 def test_download(mock_send_request, file_path: str | Path, destination: str):


### PR DESCRIPTION
# Change Summary

## Overview
Updated spice directory to be under `imap/` on S3 like it was discussed in Slack thread.

## Updated Files
- imap_data_access/file_validation.py
   - update the path


## Testing
- tests/test_file_validation.py
- tests/test_io.py
