### PR TITLE
Fixing repoint keyword in query

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -335,7 +335,10 @@ def main():  # noqa: PLR0915
         help="End date for a range of file timestamps in YYYYMMDD format",
     )
     query_parser.add_argument(
-        "--repointing", type=int, required=False, help="Repointing number (int)"
+        "--repointing",
+        type=str,
+        required=False,
+        help="Repointing number (repoint00000)",
     )
     query_parser.add_argument(
         "--version",

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -204,7 +204,7 @@ class ScienceFilePath(ImapFilePath):
         if data_level == "l0":
             extension = "pkts"
         time_field = start_time
-        if repointing:
+        if repointing is not None:
             if ScienceFilePath.is_valid_repointing(repointing):
                 time_field += f"-{repointing}"
             elif isinstance(repointing, int):

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -167,7 +167,7 @@ class ScienceFilePath(ImapFilePath):
         descriptor: str,
         start_time: str,
         version: str,
-        repointing: int | None = None,
+        repointing: int | str | None = None,
     ) -> ScienceFilePath:
         """Generate a filename from given inputs and return a ScienceFilePath instance.
 
@@ -192,7 +192,8 @@ class ScienceFilePath(ImapFilePath):
             The version of the data
         repointing : int, optional
             The repointing number for this file, optional field that
-            is not always present
+            is not always present. Should be either a string like "repointXXXXX" or an
+            integer like 12345.
 
         Returns
         -------
@@ -204,7 +205,11 @@ class ScienceFilePath(ImapFilePath):
             extension = "pkts"
         time_field = start_time
         if repointing:
-            time_field += f"-repoint{repointing:05d}"
+            if ScienceFilePath.is_valid_repointing(repointing):
+                time_field += f"-{repointing}"
+            elif isinstance(repointing, int):
+                time_field += f"-repoint{repointing:05d}"
+
         filename = (
             f"imap_{instrument}_{data_level}_{descriptor}_{time_field}_"
             f"{version}.{extension}"

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -92,7 +92,7 @@ def query(
     descriptor: Optional[str] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    repointing: Optional[str] = None,
+    repointing: Optional[Union[str, int]] = None,
     version: Optional[str] = None,
     extension: Optional[str] = None,
 ) -> list[dict[str, str]]:
@@ -180,13 +180,16 @@ def query(
     ):
         raise ValueError("Not a valid version, use format 'vXXX'.")
 
-    # check repointing follows 'repoint00000' format
     if repointing is not None:
+        # check repointing follows 'repoint00000' format
         if not file_validation.ScienceFilePath.is_valid_repointing(repointing):
-            raise ValueError(
-                "Not a valid repointing, use format repoint<num>,"
-                " where <num> is a 5 digit integer."
-            )
+            try:
+                query_params["repointing"] = int(repointing)
+            except ValueError as err:
+                raise ValueError(
+                    "Not a valid repointing, use format repoint<num>,"
+                    " where <num> is a 5 digit integer."
+                ) from err
 
         # Query API expects an integer
         query_params["repointing"] = int(repointing[-5:])

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -181,14 +181,15 @@ def query(
         raise ValueError("Not a valid version, use format 'vXXX'.")
 
     # check repointing follows 'repoint00000' format
-    if (
-        repointing is not None
-        and not file_validation.ScienceFilePath.is_valid_repointing(repointing)
-    ):
-        raise ValueError(
-            "Not a valid repointing, use format repoint<num>,"
-            " where <num> is a 5 digit integer."
-        )
+    if repointing is not None:
+        if not file_validation.ScienceFilePath.is_valid_repointing(repointing):
+            raise ValueError(
+                "Not a valid repointing, use format repoint<num>,"
+                " where <num> is a 5 digit integer."
+            )
+
+        # Query API expects an integer
+        query_params["repointing"] = int(repointing[-5:])
 
     # check extension
     if extension is not None and extension not in imap_data_access.VALID_FILE_EXTENSION:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -151,6 +151,7 @@ def test_download_already_exists(mock_send_request):
         },
         # Make sure not all query params are sent if they are missing
         {"instrument": "swe", "data_level": "l0"},
+        {"instrument": "glows", "data_level": "l1a", "repointing": "1"},
     ],
 )
 def test_query(mock_send_request, query_params: dict):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -176,7 +176,10 @@ def test_query(mock_send_request, query_params: dict):
     # Assert that the correct URL was used for the query
     sent_request = mock_send_request.call_args[0][0]
     called_url = sent_request.url
-    str_params = "&".join(f"{k}={v}" for k, v in query_params.items())
+    fixed_query = query_params.copy()
+    if "repointing" in fixed_query:
+        fixed_query["repointing"] = 1
+    str_params = "&".join(f"{k}={v}" for k, v in fixed_query.items())
     expected_url_encoded = f"https://api.test.com/query?{str_params}"
     assert called_url == expected_url_encoded
 


### PR DESCRIPTION
# Change Summary
This makes it so you can query against repointing using `--repointing repoint00001`. The actual API still takes in an integer, because the file tracking table uses ints instead of the `repointxxxxx` standard name. So this takes in `repoint00001` and transforms it before querying the HTTPS API. 

Before, the query failed because some parts were validating against `repointxxxxx` and some were validating against an integer. I think we should leave the repointing as an int in the database and in the query API, but match the standard on the outward facing wrapper here. 