### PR TITLE
Include 'l2c' in valid data levels (for IDEX)

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -88,6 +88,7 @@ VALID_DATALEVELS = {
     "l2",
     "l2a",
     "l2b",
+    "l2c",
     "l3",
     "l3a",
     "l3b",


### PR DESCRIPTION
# Change Summary

## Overview
Add "l2c" to valid data levels. IDEX has a l2c data product.

## Updated Files
- imap_data_access/__init__.py
   - Add l2c
