### PR TITLE
ENH: Adding four new SDC metakernel filename conventions

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -516,8 +516,26 @@ class SPICEFilePath(ImapFilePath):
 
     # Covers:
     # SDC generated metakernels (type: 'tm')
-    sdc_mk_filename_pattern = (
-        r"(imap)_sdc_metakernel_"
+    sdc_time_mk_filename_pattern = (
+        r"(imap)_sdc_time_"
+        r"(?P<start_year>[\d]{4})_"
+        r"v(?P<version>[\d]{3})\."
+        r"(?P<type>tm)"
+    )
+    sdc_att_ephem_hist_mk_filename_pattern = (
+        r"(imap)_sdc_attitude_ephemeris_hist_"
+        r"(?P<start_year>[\d]{4})_"
+        r"v(?P<version>[\d]{3})\."
+        r"(?P<type>tm)"
+    )
+    sdc_att_hist_mk_filename_pattern = (
+        r"(imap)_sdc_attitude_hist_"
+        r"(?P<start_year>[\d]{4})_"
+        r"v(?P<version>[\d]{3})\."
+        r"(?P<type>tm)"
+    )
+    sdc_full_mk_filename_pattern = (
+        r"(imap)_sdc_full_"
         r"(?P<start_year>[\d]{4})_"
         r"v(?P<version>[\d]{3})\."
         r"(?P<type>tm)"
@@ -545,7 +563,10 @@ class SPICEFilePath(ImapFilePath):
         re.compile(spice_prod_ver_pattern),
         re.compile(spice_frame_pattern),
         re.compile(sff_filename_pattern),
-        re.compile(sdc_mk_filename_pattern),
+        re.compile(sdc_time_mk_filename_pattern),
+        re.compile(sdc_att_ephem_hist_mk_filename_pattern),
+        re.compile(sdc_att_hist_mk_filename_pattern),
+        re.compile(sdc_full_mk_filename_pattern),
         re.compile(attitude_mk_filename_pattern),
         re.compile(ephemeris_mk_filename_pattern),
     )

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -202,10 +202,25 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("imap/spice/repoint/imap_2025_122_01.repoint.csv")
 
-    metakernel_file = SPICEFilePath("imap_sdc_metakernel_1000_v000.tm")
+    metakernel_file = SPICEFilePath("imap_sdc_time_1000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("imap/spice/mk/imap_sdc_metakernel_1000_v000.tm")
+    ] / Path("imap/spice/mk/imap_sdc_time_1000_v000.tm")
+
+    metakernel_file = SPICEFilePath("imap_sdc_attitude_hist_1000_v000.tm")
+    assert metakernel_file.construct_path() == imap_data_access.config[
+        "DATA_DIR"
+    ] / Path("imap/spice/mk/imap_sdc_attitude_hist_1000_v000.tm")
+
+    metakernel_file = SPICEFilePath("imap_sdc_attitude_ephemeris_hist_1000_v000.tm")
+    assert metakernel_file.construct_path() == imap_data_access.config[
+        "DATA_DIR"
+    ] / Path("imap/spice/mk/imap_sdc_attitude_ephemeris_hist_1000_v000.tm")
+
+    metakernel_file = SPICEFilePath("imap_sdc_full_1000_v000.tm")
+    assert metakernel_file.construct_path() == imap_data_access.config[
+        "DATA_DIR"
+    ] / Path("imap/spice/mk/imap_sdc_full_1000_v000.tm")
 
     thruster_file = SPICEFilePath("imap_0001_001_hist_00.sff")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
@@ -239,7 +254,7 @@ def test_spice_extract_spin_parts():
 
 
 def test_spice_extract_metakernel_parts():
-    file_path = SPICEFilePath("imap_sdc_metakernel_2025_v100.tm")
+    file_path = SPICEFilePath("imap_sdc_time_2025_v100.tm")
     assert file_path.spice_metadata["version"] == "100"
     assert file_path.spice_metadata["type"] == "metakernel"
     assert file_path.spice_metadata["start_date"] == datetime(2025, 1, 1)


### PR DESCRIPTION
# Change Summary

## Overview
Adding new four metakernel that SDC will produce.

## Updated Files
- imap_data_access/file_validation.py
   - new metakernel filename conventions


## Testing
- tests/test_file_validation.py
