### PR TITLE
MNT: loosen MOC's filename convention by ignoring all case sensitive checks. Update SFF convention

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -509,9 +509,11 @@ class SPICEFilePath(ImapFilePath):
     sff_filename_pattern = (
         r"(imap)_"
         r"(?P<start_year_doy>[\d]{4}_[\d]{3})_"
+        r"(?P<end_year_doy>[\d]{4}_[\d]{3})_"
+        r"(?P<type>sff)_"
         r"([a-zA-Z0-9\-_]+)_"
         r"(?P<version>[\d]{2})\."
-        r"(?P<type>sff)"
+        r"(?P<extension>csv)"
     )
 
     # Covers:
@@ -539,15 +541,15 @@ class SPICEFilePath(ImapFilePath):
     )
 
     valid_spice_regexes = (
-        re.compile(attitude_file_pattern),
-        re.compile(repoint_file_pattern),
-        re.compile(spacecraft_ephemeris_file_pattern),
-        re.compile(spice_prod_ver_pattern),
-        re.compile(spice_frame_pattern),
-        re.compile(sff_filename_pattern),
+        re.compile(attitude_file_pattern, re.IGNORECASE),
+        re.compile(repoint_file_pattern, re.IGNORECASE),
+        re.compile(spacecraft_ephemeris_file_pattern, re.IGNORECASE),
+        re.compile(spice_prod_ver_pattern, re.IGNORECASE),
+        re.compile(spice_frame_pattern, re.IGNORECASE),
+        re.compile(sff_filename_pattern, re.IGNORECASE),
         re.compile(sdc_mk_filename_pattern),
-        re.compile(attitude_mk_filename_pattern),
-        re.compile(ephemeris_mk_filename_pattern),
+        re.compile(attitude_mk_filename_pattern, re.IGNORECASE),
+        re.compile(ephemeris_mk_filename_pattern, re.IGNORECASE),
     )
 
     class InvalidSPICEFileError(Exception):

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -186,6 +186,10 @@ def test_spice_file_path():
     assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
         "imap/spice/ck/imap_1000_100_1000_100_01.ap.bc"
     )
+    file_path = SPICEFilePath("IMAP_1000_100_1000_100_01.ap.bc")
+    assert file_path.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "imap/spice/ck/IMAP_1000_100_1000_100_01.ap.bc"
+    )
 
     # Test a bad file extension too
     with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
@@ -207,10 +211,11 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("imap/spice/mk/imap_sdc_metakernel_1000_v000.tm")
 
-    thruster_file = SPICEFilePath("imap_0001_001_hist_00.sff")
+    thruster_file = SPICEFilePath("imap_2026_267_2026_267_sff_hist_02.csv")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "imap/spice/activities/imap_0001_001_hist_00.sff"
+        "imap/spice/activities/imap_2026_267_2026_267_sff_hist_02.csv"
     )
+    assert thruster_file.spice_metadata["type"] == "thruster"
 
     # MOC attitude and ephemeris metakernel files tests
     moc_att_mk = SPICEFilePath("imap_2025_005_a01.spice.mk")
@@ -221,6 +226,10 @@ def test_spice_file_path():
     moc_ephem_mk = SPICEFilePath("IMAP_2025_005_e01.mk")
     assert moc_ephem_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
         "imap/spice/mk/IMAP_2025_005_e01.mk"
+    )
+    moc_ephem_mk = SPICEFilePath("imap_2025_005_e01.mk")
+    assert moc_ephem_mk.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "imap/spice/mk/imap_2025_005_e01.mk"
     )
 
 


### PR DESCRIPTION
# Change Summary

## Overview
updated to ignore all case sensitive and updated SFF convention to match new filename convention.


## Updated Files
- imap_data_access/file_validation.py
   - main update


## Testing
- tests/test_file_validation.py
