### PR TITLE
ENA DPS - added dps filename convention

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -409,7 +409,7 @@ _SPICE_TYPE_MAPPING = {
     "de": "planetary_ephemeris",
     "pck": "planetary_constants",
     "naif": "leapseconds",
-    "imap_dps": "dps_history",
+    "imap_dps": "pointing_attitude",
     "imap_sclk_": "spacecraft_clock",
     "tf": "frames",
     "mk": "metakernel",
@@ -419,7 +419,7 @@ _SPICE_TYPE_MAPPING = {
 
 _SPICE_DIR_MAPPING = {
     "attitude_history": "ck",
-    "dps_history": "ck",
+    "pointing_attitude": "ck",
     "attitude_predict": "ck",
     "spin": "spin",
     "repoint": "repoint",

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -472,7 +472,7 @@ class SPICEFilePath(ImapFilePath):
     # DPS kernel (type: ah.bc)
     dps_file_pattern = (
         r"(?P<type>imap_dps)_"
-        r"(?P<start_year_doy>\d{4}_\d{3})_"
+        r"(?P<start_year_doy>\d{4}_\d{3})-"
         r"repoint(?P<repointing>\d{5})_"
         r"(?P<version>\d+)\."
         r"(?P<extension>ah\.bc)"

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -409,6 +409,7 @@ _SPICE_TYPE_MAPPING = {
     "de": "planetary_ephemeris",
     "pck": "planetary_constants",
     "naif": "leapseconds",
+    "imap_dps": "dps_history",
     "imap_sclk_": "spacecraft_clock",
     "tf": "frames",
     "mk": "metakernel",
@@ -418,6 +419,7 @@ _SPICE_TYPE_MAPPING = {
 
 _SPICE_DIR_MAPPING = {
     "attitude_history": "ck",
+    "dps_history": "ck",
     "attitude_predict": "ck",
     "spin": "spin",
     "repoint": "repoint",
@@ -465,6 +467,15 @@ class SPICEFilePath(ImapFilePath):
         r"(?P<end_year_doy>[\d]{4}_[\d]{3})_"
         r"(?P<version>[\d]+)\."
         r"(?P<type>ah.bc|ap.bc|spin.csv)"
+    )
+    # Covers:
+    # DPS kernel (type: ah.bc)
+    dps_file_pattern = (
+        r"(?P<type>imap_dps)_"
+        r"(?P<start_year_doy>\d{4}_\d{3})_"
+        r"repoint(?P<repointing>\d{5})_"
+        r"(?P<version>\d+)\."
+        r"(?P<extension>ah\.bc)"
     )
     # Covers:
     # Repoint Files (type: repoint.csv)
@@ -542,6 +553,7 @@ class SPICEFilePath(ImapFilePath):
 
     valid_spice_regexes = (
         re.compile(attitude_file_pattern, re.IGNORECASE),
+        re.compile(dps_file_pattern, re.IGNORECASE),
         re.compile(repoint_file_pattern, re.IGNORECASE),
         re.compile(spacecraft_ephemeris_file_pattern, re.IGNORECASE),
         re.compile(spice_prod_ver_pattern, re.IGNORECASE),

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -234,9 +234,8 @@ def test_spice_file_path():
 
     dps_pointing_file = SPICEFilePath("imap_dps_2025_121-repoint00023_007.ah.bc")
     assert dps_pointing_file.construct_path() == imap_data_access.config[
-        "DATA_DIR"] / Path(
-        "imap/spice/ck/imap_dps_2025_121-repoint00023_007.ah.bc"
-    )
+        "DATA_DIR"
+    ] / Path("imap/spice/ck/imap_dps_2025_121-repoint00023_007.ah.bc")
 
 
 def test_spice_extract_dps_pointing_parts():
@@ -248,7 +247,8 @@ def test_spice_extract_dps_pointing_parts():
     assert file_path.spice_metadata["type"] == "pointing_attitude"
     assert file_path.spice_metadata["repointing"] == "00023"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
-        "2025_121", "%Y_%j")
+        "2025_121", "%Y_%j"
+    )
     assert file_path.spice_metadata["end_date"] is None
 
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -232,6 +232,23 @@ def test_spice_file_path():
         "imap/spice/mk/imap_2025_005_e01.mk"
     )
 
+    dps_pointing_file = SPICEFilePath("imap_dps_2025_121_repoint00023_007.ah.bc")
+    assert dps_pointing_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "imap/spice/ck/imap_dps_2025_121_repoint00023_007.ah.bc"
+    )
+
+
+def test_spice_extract_dps_pointing_parts():
+    """Test the new DPS pointing kernel filename parsing."""
+    filename = "imap_dps_2025_121_repoint00023_007.ah.bc"
+    file_path = SPICEFilePath(filename)
+
+    assert file_path.spice_metadata["version"] == "007"
+    assert file_path.spice_metadata["type"] == "dps_history"
+    assert file_path.spice_metadata["repointing"] == "00023"
+    assert file_path.spice_metadata["start_date"] == datetime.strptime("2025_121", "%Y_%j")
+    assert file_path.spice_metadata["end_date"] is None
+
 
 def test_spice_extract_spin_parts():
     # Test spin

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -233,7 +233,8 @@ def test_spice_file_path():
     )
 
     dps_pointing_file = SPICEFilePath("imap_dps_2025_121-repoint00023_007.ah.bc")
-    assert dps_pointing_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+    assert dps_pointing_file.construct_path() == imap_data_access.config[
+        "DATA_DIR"] / Path(
         "imap/spice/ck/imap_dps_2025_121-repoint00023_007.ah.bc"
     )
 
@@ -246,7 +247,8 @@ def test_spice_extract_dps_pointing_parts():
     assert file_path.spice_metadata["version"] == "007"
     assert file_path.spice_metadata["type"] == "dps_history"
     assert file_path.spice_metadata["repointing"] == "00023"
-    assert file_path.spice_metadata["start_date"] == datetime.strptime("2025_121", "%Y_%j")
+    assert file_path.spice_metadata["start_date"] == datetime.strptime(
+        "2025_121", "%Y_%j")
     assert file_path.spice_metadata["end_date"] is None
 
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -245,7 +245,7 @@ def test_spice_extract_dps_pointing_parts():
     file_path = SPICEFilePath(filename)
 
     assert file_path.spice_metadata["version"] == "007"
-    assert file_path.spice_metadata["type"] == "dps_history"
+    assert file_path.spice_metadata["type"] == "pointing_attitude"
     assert file_path.spice_metadata["repointing"] == "00023"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_121", "%Y_%j")

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -232,15 +232,15 @@ def test_spice_file_path():
         "imap/spice/mk/imap_2025_005_e01.mk"
     )
 
-    dps_pointing_file = SPICEFilePath("imap_dps_2025_121_repoint00023_007.ah.bc")
+    dps_pointing_file = SPICEFilePath("imap_dps_2025_121-repoint00023_007.ah.bc")
     assert dps_pointing_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "imap/spice/ck/imap_dps_2025_121_repoint00023_007.ah.bc"
+        "imap/spice/ck/imap_dps_2025_121-repoint00023_007.ah.bc"
     )
 
 
 def test_spice_extract_dps_pointing_parts():
     """Test the new DPS pointing kernel filename parsing."""
-    filename = "imap_dps_2025_121_repoint00023_007.ah.bc"
+    filename = "imap_dps_2025_121-repoint00023_007.ah.bc"
     file_path = SPICEFilePath(filename)
 
     assert file_path.spice_metadata["version"] == "007"


### PR DESCRIPTION
# Change Summary

## Overview
Add new filename convention to imap-data-access's file_validation.py file. Update _SPICE_TYPE_MAPPING and _SPICE_DIR_MAPPING. Then add regex in SPICEFilePath() class.

For filename: imap_dps_yyyy_doy-repoint<xxxxx>_##.ah.bc

## Updated Files
- file_validation.py
   - added dps filename convention

## Testing
- test_file_validation.py