### PR TITLE
MNT: Consolidate filepath errors into the base class

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -31,11 +31,7 @@ def generate_imap_file_path(filename: str) -> ImapFilePath:
     for cls in (ScienceFilePath, AncillaryFilePath, SPICEFilePath, QuicklookFilePath):
         try:
             return cls(filename)
-        except (
-            ScienceFilePath.InvalidScienceFileError,
-            AncillaryFilePath.InvalidAncillaryFileError,
-            SPICEFilePath.InvalidSPICEFileError,
-        ):
+        except ImapFilePath.InvalidImapFileError:
             continue
     raise ValueError(
         f"Invalid file type for {filename}. It does not matchany file formats."
@@ -48,6 +44,11 @@ class ImapFilePath:
     Includes shared static methods and provides correct typing for ScienceFilePath,
     AncillaryFilePath, and SPICEFilePath.
     """
+
+    class InvalidImapFileError(Exception):
+        """Indicates a bad file type."""
+
+        pass
 
     @property
     def data_dir(self) -> Path:
@@ -119,8 +120,8 @@ class ScienceFilePath(ImapFilePath):
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "pkts"}
     _dir_prefix = "imap"
 
-    class InvalidScienceFileError(Exception):
-        """Indicates a bad file type."""
+    class InvalidScienceFileError(ImapFilePath.InvalidImapFileError):
+        """DEPRECATED: Use ImapFilePath.InvalidImapFileError instead."""
 
         pass
 
@@ -156,7 +157,7 @@ class ScienceFilePath(ImapFilePath):
         try:
             split_filename = self.extract_filename_components(self.filename)
         except ValueError as err:
-            raise self.InvalidScienceFileError(
+            raise self.InvalidImapFileError(
                 f"Invalid filename. Expected file to match format: "
                 f"{imap_data_access.FILENAME_CONVENTION}"
             ) from err
@@ -172,7 +173,7 @@ class ScienceFilePath(ImapFilePath):
 
         self.error_message = self.validate_filename()
         if self.error_message:
-            raise self.InvalidScienceFileError(f"{self.error_message}")
+            raise self.InvalidImapFileError(f"{self.error_message}")
 
     @classmethod
     def generate_from_inputs(
@@ -351,7 +352,7 @@ class ScienceFilePath(ImapFilePath):
 
         match = re.match(pattern, filename)
         if match is None:
-            raise ScienceFilePath.InvalidScienceFileError(
+            raise ScienceFilePath.InvalidImapFileError(
                 f"Filename {filename} does not match expected pattern: "
                 f"{imap_data_access.FILENAME_CONVENTION}"
             )
@@ -572,8 +573,8 @@ class SPICEFilePath(ImapFilePath):
         re.compile(ephemeris_mk_filename_pattern, re.IGNORECASE),
     )
 
-    class InvalidSPICEFileError(Exception):
-        """Indicates a bad file type."""
+    class InvalidSPICEFileError(ImapFilePath.InvalidImapFileError):
+        """DEPRECATED: Use ImapFilePath.InvalidImapFileError instead."""
 
         pass
 
@@ -627,7 +628,7 @@ class SPICEFilePath(ImapFilePath):
             If
         """
         if components["type"] not in _SPICE_TYPE_MAPPING:
-            raise SPICEFilePath.InvalidSPICEFileError(
+            raise SPICEFilePath.InvalidImapFileError(
                 f"Invalid SPICE file. Expected file to have one of the following "
                 f"file types {list(_SPICE_DIR_MAPPING.keys())}. Please reference "
                 f"the documentation to ensure the file has the "
@@ -658,7 +659,7 @@ class SPICEFilePath(ImapFilePath):
                     int(components.pop("start_year")), 1, 1
                 )
         except ValueError:
-            raise SPICEFilePath.InvalidSPICEFileError(
+            raise SPICEFilePath.InvalidImapFileError(
                 "Invalid date detect in product file name, ensure date exists"
             ) from None
 
@@ -679,7 +680,7 @@ class SPICEFilePath(ImapFilePath):
             start_date - datetime or None
             end_date - datetime or None
 
-        If a match is not found, InvalidSPICEFileError will be raised.
+        If a match is not found, InvalidImapFileError will be raised.
 
         Parameters
         ----------
@@ -701,7 +702,7 @@ class SPICEFilePath(ImapFilePath):
                 return spice_metadata
 
         # Error if no match found to accepted types
-        raise SPICEFilePath.InvalidSPICEFileError(
+        raise SPICEFilePath.InvalidImapFileError(
             f"Invalid SPICE file. Expected file to have one of the following "
             f"file types {list(_SPICE_DIR_MAPPING.keys())}. Please reference "
             f"the documentation to ensure the file has the "
@@ -731,8 +732,8 @@ class AncillaryFilePath(ImapFilePath):
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "csv", "dat", "json", "zip"}
     _dir_prefix = "imap/ancillary"
 
-    class InvalidAncillaryFileError(Exception):
-        """Indicates a bad file type."""
+    class InvalidAncillaryFileError(ImapFilePath.InvalidImapFileError):
+        """DEPRECATED: Use ImapFilePath.InvalidImapFileError instead."""
 
         pass
 
@@ -770,7 +771,7 @@ class AncillaryFilePath(ImapFilePath):
         try:
             split_filename = self.extract_filename_components(self.filename)
         except ValueError as err:
-            raise self.InvalidAncillaryFileError(
+            raise self.InvalidImapFileError(
                 f"Invalid filename. Expected file to match format: "
                 f"{imap_data_access.ANCILLARY_FILENAME_CONVENTION}"
             ) from err
@@ -785,7 +786,7 @@ class AncillaryFilePath(ImapFilePath):
 
         self.error_message = self.validate_filename()
         if self.error_message:
-            raise self.InvalidAncillaryFileError(f"{self.error_message}")
+            raise self.InvalidImapFileError(f"{self.error_message}")
 
     @classmethod
     def generate_from_inputs(
@@ -950,7 +951,7 @@ class AncillaryFilePath(ImapFilePath):
 
         match = re.match(pattern, filename)
         if match is None:
-            raise AncillaryFilePath.InvalidAncillaryFileError(
+            raise AncillaryFilePath.InvalidImapFileError(
                 f"Filename {filename} does not match expected pattern: "
                 f"{imap_data_access.ANCILLARY_FILENAME_CONVENTION}"
             )

--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -37,10 +37,8 @@ def generate_imap_input(filename: str) -> ProcessingInput:
         try:
             return cls(filename)
         except (
-            ScienceFilePath.InvalidScienceFileError,
-            AncillaryFilePath.InvalidAncillaryFileError,
-            SPICEFilePath.InvalidSPICEFileError,
             ProcessingInput.ProcessingInputError,
+            ImapFilePath.InvalidImapFileError,
         ):
             continue
     raise ValueError(

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -46,7 +46,7 @@ def test_extract_filename_components():
 
     # Descriptor is required
     invalid_filename = "imap_mag_l1a_20210101_v001.cdf"
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath.extract_filename_components(invalid_filename)
 
     valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_v001.cdf")
@@ -71,22 +71,22 @@ def test_construct_sciencefilepathmanager():
 
     # no extension
     invalid_filename = "imap_mag_l1a_burst_20210101_v001"
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # invalid extension
     invalid_filename = "imap_mag_l1a_burst_20210101_v001.abc"
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # invalid instrument
     invalid_filename = "imap_sdc_l1a_burst_20210101_v001.cdf"
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # Bad repointing, not 5 digits
     invalid_filename = "imap_mag_l1a_burst_20210101-repoint0001_v001.cdf"
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # good path with an extra "test" directory
@@ -183,7 +183,7 @@ def test_spice_file_path():
     )
 
     # Test a bad file extension too
-    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+    with pytest.raises(SPICEFilePath.InvalidImapFileError):
         SPICEFilePath("test.txt")
 
     # Test that spin and repoint goes into their own directories
@@ -346,15 +346,15 @@ def test_spice_extract_repoint_parts():
 
 def test_spice_invalid_dates():
     # Ensure the DOY is valid (DOY 410??)
-    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+    with pytest.raises(SPICEFilePath.InvalidImapFileError):
         SPICEFilePath("imap_2025_032_2025_410_003.ah.bc")
 
     # Ensure dates are valid (Month 13??)
-    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+    with pytest.raises(SPICEFilePath.InvalidImapFileError):
         SPICEFilePath("imap_90days_20251320_20260220_v01.bsp")
 
     # Ensure valid ephemeris type (type taco??)
-    with pytest.raises(SPICEFilePath.InvalidSPICEFileError):
+    with pytest.raises(SPICEFilePath.InvalidImapFileError):
         SPICEFilePath("imap_taco_20251320_20260220_v01.bsp")
 
 
@@ -375,7 +375,7 @@ def test_ancillary_file_path():
     """Tests the ``AncillaryFilePath`` class for different scenarios."""
 
     # Test for an invalid ancillary file (incorrect instrument type)
-    with pytest.raises(AncillaryFilePath.InvalidAncillaryFileError):
+    with pytest.raises(AncillaryFilePath.InvalidImapFileError):
         AncillaryFilePath.generate_from_inputs(
             instrument="invalid_instrument",  # Invalid instrument
             descriptor="test",
@@ -503,7 +503,7 @@ def test_quicklook_file_path():
     """Tests the ``QuicklookFilePath`` class for different scenarios."""
 
     # Test for an invalid quicklook file (incorrect instrument type)
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         QuicklookFilePath.generate_from_inputs(
             instrument="invalid_instrument",  # Invalid instrument
             data_level="l1a",
@@ -513,7 +513,7 @@ def test_quicklook_file_path():
             extension="png",
         )
     # Test for an invalid quicklook file (incorrect extension type)
-    with pytest.raises(ScienceFilePath.InvalidScienceFileError):
+    with pytest.raises(ScienceFilePath.InvalidImapFileError):
         QuicklookFilePath.generate_from_inputs(
             instrument="mag",
             data_level="l1a",


### PR DESCRIPTION
# Change Summary

We were having to catch each error individually which added for a lot of boilerplate code. The real root is that it is an ImapFileError and we don't really care which class was throwing it, the message gives us details there. Lets consolidate these into one common Exception on the base class and catch that in our checks for any conversion instead of special casing each individual exception. This makes the loops easier to comprehend.

I chose to leave the previous Exceptions in place in case other services were using them and just subclassed the new BaseException class, so everything is backwards compatible here too.