### PR TITLE
ENH: Cadence filepath

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -28,7 +28,13 @@ def generate_imap_file_path(filename: str) -> ImapFilePath:
     -------
     A FilePath object
     """
-    for cls in (ScienceFilePath, AncillaryFilePath, SPICEFilePath, QuicklookFilePath):
+    for cls in (
+        ScienceFilePath,
+        AncillaryFilePath,
+        SPICEFilePath,
+        QuicklookFilePath,
+        CadenceFilePath,
+    ):
         try:
             return cls(filename)
         except ImapFilePath.InvalidImapFileError:
@@ -1000,8 +1006,14 @@ class QuicklookFilePath(ScienceFilePath):
     _dir_prefix = "imap/quicklook"
 
 
-class CandenceFilePath(ScienceFilePath):
-    """Class for building and validating filepaths for Quicklook files."""
+class CadenceFilePath(ScienceFilePath):
+    """Class for building and validating filepaths for Cadence files.
+
+    These files store the processing input for the data product they
+    are associated with. This approach avoids hitting the character
+    limit imposed by batch job commands and ensures the input format
+    remains compatible with what ProcessingInputCollection expects.
+    """
 
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"json"}
     _dir_prefix = "imap/candence"

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -998,3 +998,10 @@ class QuicklookFilePath(ScienceFilePath):
 
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"jpg", "pdf", "png"}
     _dir_prefix = "imap/quicklook"
+
+
+class CandenceFilePath(ScienceFilePath):
+    """Class for building and validating filepaths for Quicklook files."""
+
+    VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"json"}
+    _dir_prefix = "imap/candence"

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -8,7 +8,7 @@ import pytest
 import imap_data_access
 from imap_data_access.file_validation import (
     AncillaryFilePath,
-    CandenceFilePath,
+    CadenceFilePath,
     QuicklookFilePath,
     ScienceFilePath,
     SPICEFilePath,
@@ -560,10 +560,10 @@ def test_quicklook_file_path():
 
 
 def test_candence_file_path():
-    """Tests the ``CandenceFilePath`` class scenarios."""
+    """Tests the ``CadenceFilePath`` class scenarios."""
     # Test for an invalid cadence file (incorrect instrument type)
-    with pytest.raises(CandenceFilePath.InvalidImapFileError):
-        CandenceFilePath.generate_from_inputs(
+    with pytest.raises(CadenceFilePath.InvalidImapFileError):
+        CadenceFilePath.generate_from_inputs(
             instrument="invalid_instrument",  # Invalid instrument
             data_level="l1a",
             descriptor="test",
@@ -572,8 +572,8 @@ def test_candence_file_path():
             extension="json",
         )
     # Test for an invalid cadence file (incorrect extension type)
-    with pytest.raises(CandenceFilePath.InvalidImapFileError):
-        CandenceFilePath.generate_from_inputs(
+    with pytest.raises(CadenceFilePath.InvalidImapFileError):
+        CadenceFilePath.generate_from_inputs(
             instrument="mag",
             data_level="l1a",
             descriptor="test",
@@ -583,7 +583,7 @@ def test_candence_file_path():
         )
 
     # Test with no repointing
-    file_no_repointing = CandenceFilePath.generate_from_inputs(
+    file_no_repointing = CadenceFilePath.generate_from_inputs(
         instrument="mag",
         data_level="l1a",
         descriptor="test",
@@ -597,7 +597,7 @@ def test_candence_file_path():
     assert file_no_repointing.construct_path() == expected_output_no_end_date
 
     # Test with repointing number
-    file_all_params = CandenceFilePath.generate_from_inputs(
+    file_all_params = CadenceFilePath.generate_from_inputs(
         instrument="mag",
         data_level="l1a",
         descriptor="test",
@@ -612,6 +612,6 @@ def test_candence_file_path():
     assert file_all_params.construct_path() == expected_output
 
     # Test by passing the file
-    file = CandenceFilePath("imap_mag_l1a_test_20210101_v001.json")
+    file = CadenceFilePath("imap_mag_l1a_test_20210101_v001.json")
     assert file.instrument == "mag"
     assert file.start_date == "20210101"

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -8,6 +8,7 @@ import pytest
 import imap_data_access
 from imap_data_access.file_validation import (
     AncillaryFilePath,
+    CandenceFilePath,
     QuicklookFilePath,
     ScienceFilePath,
     SPICEFilePath,
@@ -554,5 +555,63 @@ def test_quicklook_file_path():
 
     # Test by passing the file
     file = QuicklookFilePath("imap_mag_l1a_test_20210101_v001.png")
+    assert file.instrument == "mag"
+    assert file.start_date == "20210101"
+
+
+def test_candence_file_path():
+    """Tests the ``CandenceFilePath`` class scenarios."""
+    # Test for an invalid cadence file (incorrect instrument type)
+    with pytest.raises(CandenceFilePath.InvalidImapFileError):
+        CandenceFilePath.generate_from_inputs(
+            instrument="invalid_instrument",  # Invalid instrument
+            data_level="l1a",
+            descriptor="test",
+            start_time="20210101",
+            version="v001",
+            extension="json",
+        )
+    # Test for an invalid cadence file (incorrect extension type)
+    with pytest.raises(CandenceFilePath.InvalidImapFileError):
+        CandenceFilePath.generate_from_inputs(
+            instrument="mag",
+            data_level="l1a",
+            descriptor="test",
+            start_time="20210101",
+            version="v001",
+            extension="cdf",
+        )
+
+    # Test with no repointing
+    file_no_repointing = CandenceFilePath.generate_from_inputs(
+        instrument="mag",
+        data_level="l1a",
+        descriptor="test",
+        start_time="20210101",
+        version="v001",
+        extension="json",
+    )
+    expected_output_no_end_date = imap_data_access.config["DATA_DIR"] / Path(
+        "imap/candence/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v001.json"
+    )
+    assert file_no_repointing.construct_path() == expected_output_no_end_date
+
+    # Test with repointing number
+    file_all_params = CandenceFilePath.generate_from_inputs(
+        instrument="mag",
+        data_level="l1a",
+        descriptor="test",
+        start_time="20210101",
+        repointing=1,
+        version="v001",
+        extension="json",
+    )
+    expected_output = imap_data_access.config["DATA_DIR"] / Path(
+        "imap/candence/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v001.json"
+    )
+    assert file_all_params.construct_path() == expected_output
+
+    # Test by passing the file
+    file = CandenceFilePath("imap_mag_l1a_test_20210101_v001.json")
     assert file.instrument == "mag"
     assert file.start_date == "20210101"


### PR DESCRIPTION
# Change Summary

## Overview
Adding cadence file path class to be able to write cadence serialize() input to a s3 and then download in processing code.


## Updated Files
- imap_data_access/file_validation.py
   - adding cadence class. similar to quicklook product, we are storing these cadence input into s3 path.


## Testing
- tests/test_file_validation.py
