### PR TITLE
MNT: adding Spin and Repoint to the deserialize()

### DIFF
--- a/imap_data_access/processing_input.py
+++ b/imap_data_access/processing_input.py
@@ -485,6 +485,15 @@ class ProcessingInputCollection:
         ----------
         json_input : str
             JSON input matching the output of ProcessingInputCollection.serialize()
+            Input json are organized by input type (science and ancillary) or
+            data type (SPICE file types). Eg.
+            [
+                {"type": "spice", "files":[ordered list of SPICE files]},
+                {"type": "spin", "files": [<list of spin files>]},
+                {"type": "repoint", "files": [<latest repoint file>]},
+                {"type": "science", "files": [<list of science files>]},
+                {"type": "ancillary", "files": [<list of ancillary files>]}
+            ]
         """
         full_input = json.loads(json_input)
 
@@ -495,6 +504,10 @@ class ProcessingInputCollection:
                 self.add(AncillaryInput(*file_creator["files"]))
             elif file_creator["type"] == ProcessingInputType.SPICE_FILE.value:
                 self.add(SPICEInput(*file_creator["files"]))
+            elif file_creator["type"] == SPICESource.SPIN.value:
+                self.add(SpinInput(*file_creator["files"]))
+            elif file_creator["type"] == SPICESource.REPOINT.value:
+                self.add(RepointInput(*file_creator["files"]))
 
     def get_science_inputs(self, source: str | None = None) -> list[ProcessingInput]:
         """Return just the science files from the collection.

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -17,6 +17,7 @@ from imap_data_access.processing_input import (
     ScienceInput,
     SPICEInput,
     SpinInput,
+    SPICESource,
     generate_imap_input,
 )
 
@@ -298,6 +299,40 @@ def test_create_collection():
         },
     ]
     assert spice_collection.serialize() == json.dumps(expected_deserialized)
+
+    input_collection_str = [
+        {"type": "spice", "files": ["naif0012.tls", "imap_sclk_0001.tsc"]},
+        {"type": "science", "files": ["imap_swe_l0_raw_20260924_v007.pkts"]},
+        {"type": "spin", "files": ["imap_1000_100_1000_100_01.spin.csv"]},
+        {"type": "repoint", "files": ["imap_1000_001_03.repoint.csv"]},
+    ]
+    input_collection = processing_input.ProcessingInputCollection()
+    input_collection.deserialize(json.dumps(input_collection_str))
+    assert len(input_collection.processing_input) == 4
+    assert (
+        input_collection.processing_input[0].input_type
+        == ProcessingInputType.SPICE_FILE
+    )
+    assert (
+        input_collection.processing_input[1].input_type
+        == ProcessingInputType.SCIENCE_FILE
+    )
+    assert (
+        input_collection.processing_input[2].input_type
+        == ProcessingInputType.SPICE_FILE
+    )
+    assert (
+        input_collection.processing_input[3].input_type
+        == ProcessingInputType.SPICE_FILE
+    )
+
+    # test get_file_paths
+    assert len(input_collection.get_file_paths(data_type=SPICESource.SPIN.value)) == 1
+    assert len(input_collection.get_file_paths(data_type=SPICESource.SPICE.value)) == 2
+    assert len(input_collection.get_file_paths(data_type="l0")) == 1
+    assert (
+        len(input_collection.get_file_paths(data_type=SPICESource.REPOINT.value)) == 1
+    )
 
 
 def test_get_time_range():

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -16,8 +16,8 @@ from imap_data_access.processing_input import (
     RepointInput,
     ScienceInput,
     SPICEInput,
-    SpinInput,
     SPICESource,
+    SpinInput,
     generate_imap_input,
 )
 


### PR DESCRIPTION
# Change Summary

## Overview
Update to be able to deserialize spin and repoint data

## Updated Files
- imap_data_access/processing_input.py
   - update to be able to deserialize spin and repoint data

## Testing
- tests/test_processing_input.py
