### PR TITLE
CLI path for manual reprocessing

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -5,17 +5,20 @@ heliosphere. This package contains the data access tools for the IMAP mission. I
 provides a convenient way to query the IMAP data archive and download data files.
 """
 
+# ruff: noqa: F401
 import importlib.metadata
 import os
 from pathlib import Path
 
 from imap_data_access.file_validation import (
     AncillaryFilePath,
+    CadenceFilePath,
     ImapFilePath,
+    QuicklookFilePath,
     ScienceFilePath,
     SPICEFilePath,
 )
-from imap_data_access.io import download, query, upload
+from imap_data_access.io import download, query, reprocess, upload
 from imap_data_access.processing_input import (
     AncillaryInput,
     ProcessingInputCollection,

--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -13,6 +13,7 @@ Use
     imap-data-access download <file_path>
     imap-data-access query <query-parameters>
     imap-data-access upload <file_path>
+    imap-data-access reprocess <reprocessing parameters>
 """
 
 import argparse
@@ -211,6 +212,31 @@ def _webpoda_parser(args: argparse.Namespace):
     print("Successfully downloaded the data from webpoda.")
 
 
+def _reprocess_parser(args: argparse.Namespace):
+    """Trigger reprocessing of data for a specific time range.
+
+    Instrument, data level, and descriptor are optional.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        An object containing the parsed arguments and their values
+    """
+    if not args.start_date:
+        raise ValueError("The 'start_date' argument is required.")
+    if not args.end_date:
+        raise ValueError("The 'end_date' argument is required.")
+        # Filter to get the arguments of interest from the namespace
+    valid_args = ["start_date", "end_date", "instrument", "data_level", "descriptor"]
+    reprocess_params = {
+        key: value
+        for key, value in vars(args).items()
+        if key in valid_args and value is not None
+    }
+    imap_data_access.reprocess(**reprocess_params)
+    print("Successfully triggered reprocessing for the given parameters.")
+
+
 # PLR0915: too many statements
 def main():  # noqa: PLR0915
     """Parse the command line arguments.
@@ -256,6 +282,19 @@ def main():  # noqa: PLR0915
     help_menu_for_query = (
         "Query the IMAP SDC for files matching the query parameters. "
         "The query parameters are optional, but at least one must be provided. "
+    )
+    reprocess_help = (
+        "Trigger reprocessing for files matching the parameters in the range of the "
+        "given start and end date. Instrument, data-level, and descriptor are optional."
+        " Start date and end date are required. If no instrument is specified, "
+        "reprocessing will be triggered for all instruments. If no data-level is "
+        "specified, reprocessing will be triggered for all data-levels. "
+        "Run 'reprocess -h' for more information."
+    )
+    help_menu_for_reprocess = (
+        "Trigger reprocessing for files matching the parameters in the range of the "
+        "given start and end date. Instrument, data-level, and descriptor are optional."
+        " Start date and end date are required."
     )
     upload_help = (
         "Upload a file to the IMAP SDC. This must be the full path to the file."
@@ -428,6 +467,42 @@ def main():  # noqa: PLR0915
     )
     parser_webpoda.set_defaults(func=_webpoda_parser)
 
+    # Reprocess command (with optional arguments)
+    reprocess_parser = subparsers.add_parser(
+        "reprocess", help=reprocess_help, description=help_menu_for_reprocess
+    )
+    reprocess_parser.add_argument(
+        "--start-date",
+        type=str,
+        required=True,
+        help="Start date for reprocessing in YYYYMMDD format",
+    )
+    reprocess_parser.add_argument(
+        "--end-date",
+        type=str,
+        required=True,
+        help="End date for reprocessing in YYYYMMDD format",
+    )
+    reprocess_parser.add_argument(
+        "--instrument",
+        type=str,
+        required=False,
+        help="Name of the instrument to reprocess",
+        choices=imap_data_access.VALID_INSTRUMENTS,
+    )
+    reprocess_parser.add_argument(
+        "--data-level",
+        type=str,
+        required=False,
+        help="Data level of the product to reprocess (l0, l1a, l2, etc.)",
+    )
+    reprocess_parser.add_argument(
+        "--descriptor",
+        type=str,
+        required=False,
+        help="Descriptor of the product to reprocess (raw, burst, etc.)",
+    )
+    reprocess_parser.set_defaults(func=_reprocess_parser)
     # Parse the arguments and set the values
     try:
         args = parser.parse_args()

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -245,6 +245,94 @@ def query(
     return items
 
 
+def reprocess(
+    *,
+    start_date: str,
+    end_date: str,
+    instrument: Optional[str] = None,
+    data_level: Optional[str] = None,
+    descriptor: Optional[str] = None,
+):
+    """Trigger reprocessing of files in the IMAP data archive.
+
+    Start date and end date are required for a reprocessing Event. If data_level is
+    provided, instrument and descriptor are required. If descriptor is specified,
+    instrument must be specified as well.
+
+    Parameters
+    ----------
+    start_date : str
+        Start date in YYYYMMDD format. Note this is the date to search for files to
+        reprocess.
+    end_date : str
+        End date in YYYYMMDD format. Note this is the end date to search for files to
+        reprocess.
+    instrument : str, optional
+        Instrument name (e.g. ``mag``)
+    data_level : str, optional
+        Data level (e.g. ``l1a``)
+    descriptor : str, optional
+        Descriptor of the data product / product name (e.g. ``burst``)
+    """
+    # locals() gives us the keyword arguments passed to the function
+    # and allows us to filter out the None values
+    reprocess_params = {
+        key: value for key, value in locals().items() if value is not None
+    }
+    logger.debug("Input reprocessing parameters: %s", reprocess_params)
+
+    # ensuring other parameters are passed
+    if not end_date or not start_date:
+        raise ValueError(
+            "Start date and end date are required for a reprocessing Event."
+        )
+    if data_level:
+        if not instrument or not descriptor:
+            raise ValueError(
+                "If data_level is provided, instrument and descriptor are required."
+            )
+    elif not instrument and descriptor:
+        raise ValueError("If descriptor is provided, instrument must also be provided.")
+    # Check instrument name
+    if instrument is not None and instrument not in imap_data_access.VALID_INSTRUMENTS:
+        raise ValueError(
+            "Not a valid instrument, please choose from "
+            + ", ".join(imap_data_access.VALID_INSTRUMENTS)
+        )
+    # Check data-level
+    # do an if statement that checks that data_level was passed in,
+    # then check it against all options, l0, l1a, l1b, l2, l3 etc.
+    if data_level is not None and data_level not in imap_data_access.VALID_DATALEVELS:
+        raise ValueError(
+            "Not a valid data level, choose from "
+            + ", ".join(imap_data_access.VALID_DATALEVELS)
+        )
+    # Check start-date
+    if start_date is not None and not file_validation.ImapFilePath.is_valid_date(
+        start_date
+    ):
+        raise ValueError("Not a valid start date, use format 'YYYYMMDD'.")
+
+    # Check end-date
+    if end_date is not None and not file_validation.ImapFilePath.is_valid_date(
+        end_date
+    ):
+        raise ValueError("Not a valid end date, use format 'YYYYMMDD'.")
+    reprocess_params["reprocessing"] = "True"
+    url = f"{imap_data_access.config['DATA_ACCESS_URL']}/reprocess"
+    request = requests.Request(
+        method="POST", url=url, params=reprocess_params
+    ).prepare()
+
+    logger.info(
+        "Triggering reprocessing for %s with url %s", reprocess_params, request.url
+    )
+    with _make_request(request) as response:
+        # Decode the JSON response as a list of items
+        items = response.json()
+        logger.debug("Received JSON: %s", items)
+
+
 def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> None:
     """Upload a file to the data archive.
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -379,3 +379,79 @@ def test_upload(
 
     # Assert that the original data from the test file was sent
     assert request_sent.body == b"test file content"
+
+
+@pytest.mark.parametrize(
+    "reprocess_params",
+    [
+        {
+            "start_date": "20100101",
+            "end_date": "20100102",
+            "instrument": "idex",
+            "data_level": "l0",
+            "descriptor": "sci",
+        },
+        {"start_date": "20100101", "end_date": "20100102"},
+        {"start_date": "20100101", "end_date": "20100102", "instrument": "idex"},
+    ],
+)
+def test_reprocess(mock_send_request, reprocess_params: dict):
+    """Test a basic call to the reprocess API.
+
+    Parameters
+    ----------
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for requests.Session
+    reprocess_params : dict
+        Dictionary of key/value pairs that set the reprocessing parameters
+    """
+    mock_response = MagicMock()
+    mock_response.json.return_value = []
+    mock_send_request.return_value = mock_response
+
+    imap_data_access.reprocess(**reprocess_params)
+
+    # Should have only been one call to send
+    mock_send_request.assert_called_once()
+    # Assert that the correct URL was used for the query
+    sent_request = mock_send_request.call_args[0][0]
+    called_url = sent_request.url
+    fixed_query = reprocess_params.copy()
+    str_params = "&".join(f"{k}={v}" for k, v in fixed_query.items())
+    expected_url_encoded = (
+        f"https://api.test.com/reprocess?{str_params}&reprocessing=True"
+    )
+    assert called_url == expected_url_encoded
+
+
+def test_reprocess_only_data_level(mock_send_request):
+    """Test a call to the reprocess API that has only the data level.
+    Parameters
+    ----------
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``requests.session``
+    """
+    with pytest.raises(
+        ValueError,
+        match="If data_level is provided, instrument and descriptor are required.",
+    ):
+        imap_data_access.reprocess(
+            start_date="20251017", end_date="20251017", data_level="l1a"
+        )
+    # Should not have made any calls to urlopen
+    assert mock_send_request.call_count == 0
+
+
+def test_reprocess_bad_instrument(mock_send_request):
+    """Test a call to the reprocess API that has an invalid instrument.
+    Parameters
+    ----------
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for ``requests.session``
+    """
+    with pytest.raises(ValueError, match="Not a valid instrument"):
+        imap_data_access.reprocess(
+            start_date="20251017", end_date="20251017", instrument="sdc"
+        )
+    # Should not have made any calls to urlopen
+    assert mock_send_request.call_count == 0


### PR DESCRIPTION
# Change Summary

## Overview
Add manual triggering of reprocessing to the imap-data-access command line interface. This will send a POST request with the given parameters to the reprocessing api endpoint which will trigger batch starter. 

## Updated Files
- imap_data_access/cli.py
   - Add cli functionality 
-imap_data_access/io.py
   - Add function to send a request to the api endpoint

## Testing
reprocess function tests
