### PR TITLE
223 update imap dps kernel naming convention

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -491,8 +491,8 @@ class SPICEFilePath(ImapFilePath):
     # DPS kernel (type: ah.bc)
     dps_file_pattern = (
         r"(?P<type>imap_dps)_"
-        r"(?P<start_year_doy>\d{4}_\d{3})-"
-        r"repoint(?P<repointing>\d{5})_"
+        r"(?P<start_year_doy>\d{4}_\d{3})_"
+        r"(?P<end_year_doy>[\d]{4}_[\d]{3})_"
         r"(?P<version>\d+)\."
         r"(?P<extension>ah\.bc)"
     )

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -224,24 +224,26 @@ def test_spice_file_path():
         "imap/spice/mk/imap_2025_005_e01.mk"
     )
 
-    dps_pointing_file = SPICEFilePath("imap_dps_2025_121-repoint00023_007.ah.bc")
+    dps_pointing_file = SPICEFilePath("imap_dps_2025_121_2025_202_07.ah.bc")
     assert dps_pointing_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
-    ] / Path("imap/spice/ck/imap_dps_2025_121-repoint00023_007.ah.bc")
+    ] / Path("imap/spice/ck/imap_dps_2025_121_2025_202_07.ah.bc")
 
 
 def test_spice_extract_dps_pointing_parts():
     """Test the new DPS pointing kernel filename parsing."""
-    filename = "imap_dps_2025_121-repoint00023_007.ah.bc"
+    filename = "imap_dps_2025_121_2025_202_07.ah.bc"
     file_path = SPICEFilePath(filename)
 
-    assert file_path.spice_metadata["version"] == "007"
+    assert file_path.spice_metadata["version"] == "07"
     assert file_path.spice_metadata["type"] == "pointing_attitude"
-    assert file_path.spice_metadata["repointing"] == "00023"
+    assert file_path.spice_metadata["repointing"] is None
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_121", "%Y_%j"
     )
-    assert file_path.spice_metadata["end_date"] is None
+    assert file_path.spice_metadata["end_date"] == datetime.strptime(
+        "2025_202", "%Y_%j"
+    )
 
 
 def test_spice_extract_spin_parts():

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -237,7 +237,6 @@ def test_spice_extract_dps_pointing_parts():
 
     assert file_path.spice_metadata["version"] == "07"
     assert file_path.spice_metadata["type"] == "pointing_attitude"
-    assert file_path.spice_metadata["repointing"] is None
     assert file_path.spice_metadata["start_date"] == datetime.strptime(
         "2025_121", "%Y_%j"
     )


### PR DESCRIPTION
# Change Summary
Updating the pointing attitude kernel to match the attitude history kernel name.

## Updated Files
- imap_data_access/file_validation.py
   - remove repointNNNN from regex
   - add end_year_doy group to regex
- tests/test_file_validation.py
   - Update test coverage for new naming convention

Closes: #223 