### PR TITLE
MNT: bump version v0.30.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imap-data-access"
-version = "0.29.0"
+version = "0.30.0"
 description = "IMAP SDC Data Access"
 authors = [{name = "IMAP SDC Developers", email = "imap-sdc@lists.lasp.colorado.edu"}]
 readme = "README.md"


### PR DESCRIPTION
# Change Summary

## Overview
Release required for using science frames kernel


## Updated Files
- pyproject.toml
   - minor version bump -> 0.30.0
