### PR TITLE
Rename CadenceFilePath to DependencyFilePath

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from imap_data_access.file_validation import (
     AncillaryFilePath,
-    CadenceFilePath,
+    DependencyFilePath,
     ImapFilePath,
     QuicklookFilePath,
     ScienceFilePath,
@@ -33,7 +33,7 @@ __all__ = [
     "VALID_INSTRUMENTS",
     "AncillaryFilePath",
     "AncillaryInput",
-    "CadenceFilePath",
+    "DependencyFilePath",
     "ImapFilePath",
     "ProcessingInputCollection",
     "QuicklookFilePath",

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -33,7 +33,7 @@ def generate_imap_file_path(filename: str) -> ImapFilePath:
         AncillaryFilePath,
         SPICEFilePath,
         QuicklookFilePath,
-        CadenceFilePath,
+        DependencyFilePath,
     ):
         try:
             return cls(filename)
@@ -1056,8 +1056,8 @@ class QuicklookFilePath(ScienceFilePath):
     _dir_prefix = "imap/quicklook"
 
 
-class CadenceFilePath(ScienceFilePath):
-    """Class for building and validating filepaths for Cadence files.
+class DependencyFilePath(ScienceFilePath):
+    """Class for building and validating filepaths for dependency files.
 
     These files store the processing input for the data product they
     are associated with. This approach avoids hitting the character
@@ -1066,4 +1066,4 @@ class CadenceFilePath(ScienceFilePath):
     """
 
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"json"}
-    _dir_prefix = "imap/cadence"
+    _dir_prefix = "imap/dependency"

--- a/tests/test_config_options.py
+++ b/tests/test_config_options.py
@@ -1,5 +1,5 @@
 """Tests for the various configs that a user can set."""
-# ruff: noqa: S603PLR0912
+# ruff: noqa: S603
 # subprocess call: check for execution of untrusted input
 
 import os

--- a/tests/test_config_options.py
+++ b/tests/test_config_options.py
@@ -1,5 +1,5 @@
 """Tests for the various configs that a user can set."""
-# ruff: noqa: S603
+# ruff: noqa: S603PLR0912
 # subprocess call: check for execution of untrusted input
 
 import os

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -8,7 +8,7 @@ import pytest
 import imap_data_access
 from imap_data_access.file_validation import (
     AncillaryFilePath,
-    CadenceFilePath,
+    DependencyFilePath,
     ImapFilePath,
     QuicklookFilePath,
     ScienceFilePath,
@@ -597,11 +597,11 @@ def test_quicklook_file_path():
     assert file.start_date == "20210101"
 
 
-def test_cadence_file_path():
-    """Tests the ``CadenceFilePath`` class scenarios."""
-    # Test for an invalid cadence file (incorrect instrument type)
-    with pytest.raises(CadenceFilePath.InvalidImapFileError):
-        CadenceFilePath.generate_from_inputs(
+def test_dependency_file_path():
+    """Tests the ``DependencyFilePath`` class scenarios."""
+    # Test for an invalid dependency file (incorrect instrument type)
+    with pytest.raises(DependencyFilePath.InvalidImapFileError):
+        DependencyFilePath.generate_from_inputs(
             instrument="invalid_instrument",  # Invalid instrument
             data_level="l1a",
             descriptor="test",
@@ -609,9 +609,9 @@ def test_cadence_file_path():
             version="v001",
             extension="json",
         )
-    # Test for an invalid cadence file (incorrect extension type)
-    with pytest.raises(CadenceFilePath.InvalidImapFileError):
-        CadenceFilePath.generate_from_inputs(
+    # Test for an invalid dependency file (incorrect extension type)
+    with pytest.raises(DependencyFilePath.InvalidImapFileError):
+        DependencyFilePath.generate_from_inputs(
             instrument="mag",
             data_level="l1a",
             descriptor="test",
@@ -621,7 +621,7 @@ def test_cadence_file_path():
         )
 
     # Test with no repointing
-    file_no_repointing = CadenceFilePath.generate_from_inputs(
+    file_no_repointing = DependencyFilePath.generate_from_inputs(
         instrument="mag",
         data_level="l1a",
         descriptor="test",
@@ -630,12 +630,12 @@ def test_cadence_file_path():
         extension="json",
     )
     expected_output_no_end_date = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/cadence/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v001.json"
+        "imap/dependency/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v001.json"
     )
     assert file_no_repointing.construct_path() == expected_output_no_end_date
 
     # Test with repointing number
-    file_all_params = CadenceFilePath.generate_from_inputs(
+    file_all_params = DependencyFilePath.generate_from_inputs(
         instrument="mag",
         data_level="l1a",
         descriptor="test",
@@ -645,11 +645,11 @@ def test_cadence_file_path():
         extension="json",
     )
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/cadence/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v001.json"
+        "imap/dependency/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v001.json"
     )
     assert file_all_params.construct_path() == expected_output
 
     # Test by passing the file
-    file = CadenceFilePath("imap_mag_l1a_test_20210101_v001.json")
+    file = DependencyFilePath("imap_mag_l1a_test_20210101_v001.json")
     assert file.instrument == "mag"
     assert file.start_date == "20210101"


### PR DESCRIPTION
# Change Summary

## Overview
JSON filepaths containing the serialized processingInputCollection will be passed into every batch job command. Previously, this was only being done for cadence files. This PR is to rename the CadenceFilePath class to the broader DependencyFilePath. 

## Updated Files
All files: 
  - rename cadence -> dependency