### PR TITLE
Adding 'End_date' parameter when query by Filename

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -231,6 +231,9 @@ def _query_parser(args: argparse.Namespace):
         file_path = generate_imap_file_path(args.filename)
         # ancillary file query
         if isinstance(file_path, AncillaryFilePath):
+            # set end_date param in case none is provided
+            if file_path.end_date is None:
+                file_path.end_date = file_path.start_date
             query_params = {
                 "table": "ancillary",
                 "instrument": file_path.instrument,
@@ -240,7 +243,6 @@ def _query_parser(args: argparse.Namespace):
                 "version": file_path.version,
                 "extension": file_path.extension,
             }
-            # TODO: add an end_date value if not provided
         # science table query
         elif isinstance(file_path, ScienceFilePath):
             query_params = {
@@ -249,6 +251,7 @@ def _query_parser(args: argparse.Namespace):
                 "data_level": file_path.data_level,
                 "descriptor": file_path.descriptor,
                 "start_date": file_path.start_date,
+                "end_date": file_path.start_date,
                 "repointing": file_path.repointing,
                 "version": file_path.version,
                 "extension": file_path.extension,


### PR DESCRIPTION
# Setting End_date Parameter when using filename

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Fixing a bug that when a user queries by the filename `End_date` never gets sets, so if there is two versions of the file with only differing `start_dates` then both will be returned (if querying by the filename of the earlier date).

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->


## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- cli.py

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
