### PR TITLE
Api key capitalization

### DIFF
--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -32,6 +32,10 @@ def _make_request(request: requests.PreparedRequest):
     when making HTTP requests and yield the response body.
     """
     logger.debug("Making request: %s", request)
+    if imap_data_access.config["API_KEY"]:
+        # Add the API key to the request headers if it exists
+        request.headers["x-api-key"] = imap_data_access.config["API_KEY"]
+
     try:
         with requests.Session() as session:
             response = session.send(request)
@@ -408,8 +412,7 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
     # We send a GET request with the filename and the server
     # will respond with an s3 presigned URL that we can use
     # to upload the file to the data archive
-    headers = {"x-api-key": api_key} if api_key else {}
-    request = requests.Request("GET", url, headers=headers).prepare()
+    request = requests.Request("GET", url).prepare()
 
     with _make_request(request) as response:
         s3_url = response.json()

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -408,7 +408,7 @@ def upload(file_path: Union[Path, str], *, api_key: Optional[str] = None) -> Non
     # We send a GET request with the filename and the server
     # will respond with an s3 presigned URL that we can use
     # to upload the file to the data archive
-    headers = {"X-api-key": api_key} if api_key else {}
+    headers = {"x-api-key": api_key} if api_key else {}
     request = requests.Request("GET", url, headers=headers).prepare()
 
     with _make_request(request) as response:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -328,7 +328,7 @@ def test_upload_no_file(mock_send_request):
 )
 @pytest.mark.parametrize(
     ("api_key", "expected_header"),
-    [(None, {}), ("test-api-key", {"X-api-key": "test-api-key"})],
+    [(None, {}), ("test-api-key", {"x-api-key": "test-api-key"})],
 )
 def test_upload(
     mock_send_request,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -349,7 +349,7 @@ def test_upload(
     expected_header : dict
         The expected header to be sent with the request
     """
-    monkeypatch.setitem(imap_data_access.config, "API_KEY", None)
+    monkeypatch.setitem(imap_data_access.config, "API_KEY", api_key)
     mock_send_request.return_value.json.return_value = "https://s3-test-bucket.com"
     # Call the upload function
     file_to_upload = imap_data_access.config["DATA_DIR"] / upload_file_path
@@ -357,7 +357,7 @@ def test_upload(
     file_to_upload.write_bytes(b"test file content")
 
     os.chdir(imap_data_access.config["DATA_DIR"])
-    imap_data_access.upload(upload_file_path, api_key=api_key)
+    imap_data_access.upload(upload_file_path)
 
     # Should have been two calls to make a request
     # 1. To get the s3 upload url


### PR DESCRIPTION
The backend wanted "x-api-key" in the header (lowercase x), so change it here since it is unused currently.

We also are adding this to more routes than just upload, so add it generically to any request rather than individually in each routine.