### PR TITLE
REL: v0.32.0 version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imap-data-access"
-version = "0.31.0"
+version = "0.32.0"
 description = "IMAP SDC Data Access"
 authors = [{name = "IMAP SDC Developers", email = "imap-sdc@lists.lasp.colorado.edu"}]
 readme = "README.md"


### PR DESCRIPTION
Forgot to bump the version in pyproject.toml, so the release wasn't published.

https://github.com/IMAP-Science-Operations-Center/imap-data-access/actions/runs/16349103017/job/46190834583