### PR TITLE
I-ALiRT - added new extension

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -793,7 +793,14 @@ class AncillaryFilePath(ImapFilePath):
         "<mission>_<instrument>_<description>_"
         "<start_date>(_<end_date>)_<version>.<extension>"
     )
-    VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "csv", "dat", "json", "zip", "tsv"}
+    VALID_EXTENSIONS: typing.ClassVar[set[str]] = {
+        "cdf",
+        "csv",
+        "dat",
+        "json",
+        "zip",
+        "tsv",
+    }
     _dir_prefix = "imap/ancillary"
 
     class InvalidAncillaryFileError(ImapFilePath.InvalidImapFileError):


### PR DESCRIPTION
# Change Summary

## Overview
The POC will use the AncillaryFilePath class to upload the DSN schedule. However, they requested to use the format .tsv. We currently don't have that listed as a supported file extension. This PR changes that. 

## Updated Files
- file_validation.py
   - Adds acceptable extension .tsv
