### PR TITLE
Add handling for uploading a file with an s3 tag

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -281,7 +281,7 @@ def _upload_parser(args: argparse.Namespace):
     args : argparse.Namespace
         An object containing the parsed arguments and their values
     """
-    imap_data_access.upload(args.file_path)
+    imap_data_access.upload(args.file_path, args.manually_reprocessed)
     print("Successfully uploaded the file to the IMAP SDC")
 
 
@@ -466,6 +466,10 @@ def main():  # noqa: PLR0915
         "This must be the full path to the file."
         "\nE.g. imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts"
     )
+    manually_repocessed_flag_help = (
+        "This flag indicates that the file was reprocessed due to a manual "
+        "reprocessing API event. On upload, the file will be tagged with 'reprocessed'."
+    )
     query_help = (
         "Query the IMAP SDC for files matching the query parameters. "
         "The query parameters are optional, but at least one must be provided. "
@@ -491,11 +495,13 @@ def main():  # noqa: PLR0915
     upload_help = (
         "Upload a file to the IMAP SDC. This must be the full path to the file."
         "\nE.g. imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts. "
-        "Run 'upload -h' for more information."
+        "Run 'upload -h' for more information. "
     )
     help_menu_for_upload = (
         "Upload a file to the IMAP SDC. This must be the full path to the file."
         "\nE.g. imap/mag/l0/2025/01/imap_mag_l0_raw_20250101_v001.pkts. "
+        "You can add the --manually_reprocessed flag to indicate that this file was"
+        " reprocessed due to a manual reprocessing API event."
     )
     url_help = (
         "URL of the IMAP SDC API. "
@@ -553,6 +559,11 @@ def main():  # noqa: PLR0915
         "upload", help=upload_help, description=help_menu_for_upload
     )
     parser_upload.add_argument("file_path", type=Path, help=file_path_help)
+    parser_upload.add_argument(
+        "--manually_reprocessed",
+        action="store_true",
+        help=manually_repocessed_flag_help,
+    )
     parser_upload.set_defaults(func=_upload_parser)
 
     # Webpoda command


### PR DESCRIPTION
# Change Summary

## Overview
We need to add capabilities to upload a file to s3 with a "manually_reprocessed" tag. This is for the purpose of being able to distinguish whether a file was reprocessed due to a "manual reprocessing event" e.g. `imap-data-access reprocessed --instrument idex`. 

The tag is vital because we check for duplicate jobs by looking if a dependency file already exists in S3. Since the dependency file contains a hash of the serialized dependencies, it’s unique to that job. 
 
Sometimes, though, we want to reprocess a job that has already been run with the same dependencies — for example, if the software has been updated. We need a way for batch_starter to tell whether a job is a manually triggered reprocessing job or not. Eventually this tag will be sent from the indexer to the event that triggers the batch job. 

This has been tested in AWS with the code from this sds-data-manager PR. 


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- imap_data_access/cli.py
   - Handle to upload an s3 file with a tag. 
- imap_data_access/io.py
   - Update the api all to add the query parameter to indicate s3 tagging

## Testing
Add test for the s3 tag
