### PR TITLE
New Spice Kernel for I-ALiRT

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -477,6 +477,7 @@ _SPICE_TYPE_MAPPING = {
     "tm": "metakernel",
     "sff": "thruster",
     "L1_de": "lagrange_point",
+    "bcp": "high_precision_planetary_constants",
 }
 
 _SPICE_DIR_MAPPING = {
@@ -500,6 +501,7 @@ _SPICE_DIR_MAPPING = {
     "metakernel": "mk",
     "thruster": "activities",
     "lagrange_point": "spk",
+    "high_precision_planetary_constants": "bcp",
 }
 """These are the valid extensions for SPICE files according to NAIF
 https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html


### PR DESCRIPTION
# Change Summary

## Overview
This adds the SPICE kernel: 
earth_latest_high_prec.bpc
with naming convention:
earth_000101_yymmdd_yymmdd.bpc

to the list of kernels.

## Updated Files
- file_validation.py
   - Add new kernel
