### PR TITLE
'latest' Return Highest Version Number Per Day

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -380,7 +380,7 @@ def add_query_args(subparser: ArgumentParser) -> None:
         required=False,
         help="Version of the product in the format 'v001'."
         " Must have one other parameter to run."
-        " Passing 'latest' will return latest version of a file",
+        " Passing 'latest' will return latest version of a file per day",
     )
     subparser.add_argument(
         "--extension", type=str, required=False, help="File extension (cdf, pkts)"

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -290,12 +290,22 @@ def query(
 
     # if latest version was included in search then filter returned query for largest.
     if (version == "latest") and items:
-        max_version = max(int(each_dict.get("version")[1:4]) for each_dict in items)
+        latest_per_day = {}
+        for item in items:
+            day = item["start_date"]
+            version_num = int(item["version"][1:4])
+            # filter by highest version per day
+            if (day not in latest_per_day) or (
+                version_num > latest_per_day[day]["_version_num"]
+            ):
+                # add extra field to identify version number
+                latest_per_day[day] = {**item, "_version_num": version_num}
+        # remove the extra field
         items = [
-            each_dict
-            for each_dict in items
-            if int(each_dict["version"][1:4]) == max_version
+            {k: version for k, version in val.items() if k != "_version_num"}
+            for val in latest_per_day.values()
         ]
+
     return items
 
 


### PR DESCRIPTION
# Updating the latest flag to return the highest version number per each day

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Fix for the bug found by @tech3371 in #239 for the latest versioning flag. 

Currently, the api works like this:
SWE has 32 files in the Science table currently.
The command `imap-data-access query --instrument swe --version latest` will return 
<img width="944" height="102" alt="Screen Shot 2025-08-13 at 11 45 22 AM" src="https://github.com/user-attachments/assets/189f8e8e-2f93-4225-bd06-352649b7e027" />


The changes in this PR will cause `imap-data-access query --instrument swe --version latest` to return 
<img width="944" height="171" alt="Screen Shot 2025-08-13 at 11 45 50 AM" src="https://github.com/user-attachments/assets/57760ee2-a800-46e9-8138-ebceb694c865" />


Multiple files, each one corresponding to a different start date and the highest version number it holds. 

Closes #239 

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->


## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->


## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- io.py
- cli.py

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
