### PR TITLE
FIX: Add end_date to query to restrict future file searches

### DIFF
--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -528,6 +528,8 @@ def _get_latest_version_file_path(
         data_level="l0",
         descriptor="raw",
         start_date=start_time.strftime("%Y%m%d"),
+        # start_date is >= so we need to add an end_date to restrict the query
+        end_date=start_time.strftime("%Y%m%d"),
         repointing=repointing,
     )
     if len(current_files):


### PR DESCRIPTION
We only passed in start_date to our query before, but this does a >= search into the future, which meant that during our I&T testing when more files are uploaded and in the future, we can accidentally match on them. We only want the specific day of this file, so add the end_date parameter as well.

Noticed this when downloading MAG packets with today's date and I was getting a v004 file because there is future 2026 files in our DB that the query matched against.