### PR TITLE
Added support for .dat extension science input files

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -127,7 +127,7 @@ class ScienceFilePath(ImapFilePath):
         "<mission>_<instrument>_<datalevel>_<descriptor>_"
         "<startdate>(-<repointing>)_<version>.<extension>"
     )
-    VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "pkts"}
+    VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "pkts", "dat"}
     _dir_prefix = "imap"
 
     class InvalidScienceFileError(ImapFilePath.InvalidImapFileError):

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -114,6 +114,19 @@ def test_construct_sciencefilepathmanager():
     assert sfm.is_valid_for_start_date(datetime(2021, 1, 1))
     assert not sfm.is_valid_for_start_date(datetime(2021, 1, 3))
 
+    # good path with dat extension
+    valid_filepath = Path("/test/imap_glows_l3d_e-dens_19470303-cr02094_v001.dat")
+    dat = ScienceFilePath(valid_filepath)
+
+    assert dat.mission == "imap"
+    assert dat.instrument == "glows"
+    assert dat.data_level == "l3d"
+    assert dat.descriptor == "e-dens"
+    assert dat.start_date == "19470303"
+    assert dat.cr == 2094
+    assert dat.version == "v001"
+    assert dat.extension == "dat"
+
 
 def test_is_valid_date():
     """Tests the ``is_valid_date`` method."""

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -285,7 +285,7 @@ def test_query_bad_params(mock_send_request):
             "extension",
             "badInput",
             r"Not a valid extension for 'science', "
-            r"choose from \{'(cdf|pkts)', '(pkts|cdf)'\}.",
+            r"choose from \{'(cdf|pkts|dat)', '(cdf|pkts|dat)', '(pkts|cdf|dat)'\}.",
         ),
     ],
 )


### PR DESCRIPTION
# Change Summary

## Overview
Added support for .dat extension science input files. This is for support for GLOWS L3D which outputs both CDF files and DAT files. 

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- file_validation.py
   - added "dat" to the set of valid extensions
- test_file_validation.py
   - updated tests to reflect dat support in production
- test_io.py
   - error now includes dat as a "choose from" in the set of valid extensions