### PR TITLE
MNT: Update webpoda url to pull from after launch location

### DIFF
--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -32,7 +32,7 @@ WEBPODA_APID_URL = "https://lasp.colorado.edu/ops/imap/poda/dap2/apids"
 # SID1 == FLIGHT instrument telemetry and spacecraft telemetry after launch
 # SID2 == FLIGHT instrument telemetry and spacecraft telemetry before launch
 # SID3 == Instrument simulator telemetry and spacecraft simulator telemetry
-SYSTEM_ID = "SID2"
+SYSTEM_ID = "SID1"
 
 # https://lasp.colorado.edu/galaxy/spaces/IMAP/pages/155648242/Packet+Decommutation+Resource+Page+-+IMAP
 INSTRUMENT_APIDS = {

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -39,7 +39,7 @@ def test_get_packet_times_ert(mock_send_request, mock_request):
     # Verify the request was prepared correctly
     mock_request.assert_called_once_with(
         "GET",
-        f"https://lasp.colorado.edu/ops/imap/poda/dap2/apids/SID2/apid_{apid}.txt",
+        f"https://lasp.colorado.edu/ops/imap/poda/dap2/apids/SID1/apid_{apid}.txt",
         headers={"Authorization": "Basic test_token"},
         params=(
             f"ert>={start_time.strftime('%Y-%m-%dT%H:%M:%S')}"
@@ -68,7 +68,7 @@ def test_get_packet_binary_data_sctime(mock_send_request, mock_request):
     # Verify the request was prepared correctly
     mock_request.assert_called_once_with(
         "GET",
-        f"https://lasp.colorado.edu/ops/imap/poda/dap2/apids/SID2/apid_{apid}.bin",
+        f"https://lasp.colorado.edu/ops/imap/poda/dap2/apids/SID1/apid_{apid}.bin",
         headers={"Authorization": "Basic test_token"},
         params=(
             f"time>={start_time.strftime('%Y-%m-%dT%H:%M:%S')}"


### PR DESCRIPTION
# Change Summary

## Overview

I decided to just update the SID number directly rather than allowing for this to be optional/passed through. I think we can add that capability later if it is desired, but theoretically now everyone will only want to get flight packets and not care about pre-launch anymore. We can always downgrade this tool to versions <0.35 to get pre-launch data too if desired I suppose.

closes #267 