### PR TITLE
MNT: Allow for repoint or repoint.csv filenames

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -459,7 +459,9 @@ _SPICE_TYPE_MAPPING = {
     "ah.bc": "attitude_history",
     "ap.bc": "attitude_predict",
     "spin.csv": "spin",
+    "spin": "spin",
     "repoint.csv": "repoint",
+    "repoint": "repoint",
     "recon": "ephemeris_reconstructed",
     "nom": "ephemeris_nominal",
     "pred": "ephemeris_predicted",
@@ -534,7 +536,7 @@ class SPICEFilePath(ImapFilePath):
         r"(?P<start_year_doy>[\d]{4}_[\d]{3})_"
         r"(?P<end_year_doy>[\d]{4}_[\d]{3})_"
         r"(?P<version>[\d]+)\."
-        r"(?P<type>ah.bc|ap.bc|spin.csv)"
+        r"(?P<type>ah.bc|ap.bc|spin.csv|spin)"
     )
     # Covers:
     # DPS kernel (type: ah.bc)
@@ -546,12 +548,12 @@ class SPICEFilePath(ImapFilePath):
         r"(?P<extension>ah\.bc)"
     )
     # Covers:
-    # Repoint Files (type: repoint.csv)
+    # Repoint Files (type: repoint.csv, or repoint)
     repoint_file_pattern = (
         r"(imap)_"
         r"(?P<end_year_doy>[\d]{4}_[\d]{3})_"
         r"(?P<version>[\d]+)\."
-        r"(?P<type>repoint.csv)"
+        r"(?P<type>repoint.csv|repoint)"
     )
     # Covers:
     # Reconstructed (type: recon)

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -219,6 +219,11 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("imap/spice/repoint/imap_2025_122_01.repoint.csv")
 
+    repoint_file_path = SPICEFilePath("imap_2025_122_01.repoint")
+    assert repoint_file_path.construct_path() == imap_data_access.config[
+        "DATA_DIR"
+    ] / Path("imap/spice/repoint/imap_2025_122_01.repoint")
+
     metakernel_file = SPICEFilePath("imap_sdc_metakernel_1000_v000.tm")
     assert metakernel_file.construct_path() == imap_data_access.config[
         "DATA_DIR"
@@ -279,9 +284,10 @@ def test_spice_extract_dps_pointing_parts():
     print(file_path.spice_metadata)
 
 
-def test_spice_extract_spin_parts():
+@pytest.mark.parametrize("suffix", ["spin", "spin.csv"])
+def test_spice_extract_spin_parts(suffix):
     # Test spin
-    file_path = SPICEFilePath("imap_2025_122_2025_122_01.spin.csv")
+    file_path = SPICEFilePath(f"imap_2025_122_2025_122_01.{suffix}")
     assert file_path.spice_metadata["version"] == "01"
     assert file_path.spice_metadata["type"] == "spin"
     assert file_path.spice_metadata["start_date"] == datetime.strptime(


### PR DESCRIPTION
The MOC has removed the .csv suffix from the spin and repoint files to align with other items. Add handling for the new non-csv suffix, but leave the old handling in-tact still so we can use either version.

