### PR TITLE
FIX: Small Forces File changed naming convention

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -596,10 +596,9 @@ class SPICEFilePath(ImapFilePath):
         r"(imap)_"
         r"(?P<start_year_doy>[\d]{4}_[\d]{3})_"
         r"(?P<end_year_doy>[\d]{4}_[\d]{3})_"
-        r"(?P<type>sff)_"
         r"([a-zA-Z0-9\-_]+)_"
         r"(?P<version>[\d]{2})\."
-        r"(?P<extension>sff)"
+        r"(?P<type>sff)"
     )
 
     # Covers:

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -229,9 +229,9 @@ def test_spice_file_path():
         "DATA_DIR"
     ] / Path("imap/spice/mk/imap_sdc_metakernel_1000_v000.tm")
 
-    thruster_file = SPICEFilePath("imap_2026_267_2026_267_sff_hist_02.sff")
+    thruster_file = SPICEFilePath("imap_2026_267_2026_267_hist_02.sff")
     assert thruster_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
-        "imap/spice/activities/imap_2026_267_2026_267_sff_hist_02.sff"
+        "imap/spice/activities/imap_2026_267_2026_267_hist_02.sff"
     )
     assert thruster_file.spice_metadata["type"] == "thruster"
 


### PR DESCRIPTION
The MOC does not have "sff" within the filename, only as the extension, so remove that from the filename matching.

This was identified after looking at the files attempted to be uploaded to the SDC.