### PR TITLE
FIX: Handle potential NaNs in the middle of the repointing files

### DIFF
--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -422,12 +422,16 @@ def download_repointing_data(
     # NOTE: We iterate over the repointings rather than the packet times because it is
     #       assumed to be the shorter list (1/day vs 1000s of packets/day per apid)
     for i in range(len(repointings) - 1):
-        pointing_start = datetime.datetime.strptime(
-            repointings[i]["repoint_end_utc"], "%Y-%m-%d %H:%M:%S.%f"
-        )
+        # skip i and i+1 values that are NaN
+        if repointings[i]["repoint_end_utc"].lower() == "nan":
+            # This pointing never "started"
+            continue
         if repointings[i + 1]["repoint_end_utc"].lower() == "nan":
             # Missing repointing end time, so it isn't a complete "pointing" yet.
             continue
+        pointing_start = datetime.datetime.strptime(
+            repointings[i]["repoint_end_utc"], "%Y-%m-%d %H:%M:%S.%f"
+        )
         if pointing_start > packet_times[-1]:
             # This pointing is after the last packet time, so skip it
             logger.debug(

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -164,6 +164,7 @@ def test_download_repointing_data(
             # An unfinished repointing maneuver may have NaNs in the end times
             # Make sure we can handle this and ignore it
             "10,0,NaN,NaN,2024-12-03T00:00:00.000000,NaN,4\n"
+            "10,0,12,0,2024-12-04T00:00:00.000000,2024-12-04 00:15:00.000,5\n"
         )
 
     start_time = datetime.datetime(2024, 12, 1, 0, 0, 0)


### PR DESCRIPTION
We are getting files with NaN values in the middle and that is causing the first conversion to date of the start_time to fail now. Check for that case and skip over any repointings with an invalid start date.