### PR TITLE
MNT: Add optional odNNN in SPICE ephemeris file names

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -565,6 +565,7 @@ class SPICEFilePath(ImapFilePath):
     spacecraft_ephemeris_file_pattern = (
         r"(imap)_"
         r"(?P<type>[a-zA-Z0-9\-]+)_"
+        r"(?:od\d{3}_)?"  # Optionally match and ignore odNNN
         r"(?P<start_date>[\d]{8})_"
         r"(?P<end_date>[\d]{8})"
         r"(?:|_v(?P<version>[\d]*))\."

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -267,6 +267,20 @@ def test_spice_file_path():
     ] / Path("imap/spice/spk/L1_de431.bsp")
     assert lagrange_point_file.spice_metadata["type"] == "lagrange_point"
 
+    # Ephemeris with "od" in the filename
+    ephem_file = SPICEFilePath("imap_pred_od004_20251002_20251113_v01.bsp")
+    assert ephem_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "imap/spice/spk/imap_pred_od004_20251002_20251113_v01.bsp"
+    )
+    assert ephem_file.spice_metadata["type"] == "ephemeris_predicted"
+
+    # Ephemeris without "od" in the filename
+    ephem_file = SPICEFilePath("imap_pred_20251002_20251113_v01.bsp")
+    assert ephem_file.construct_path() == imap_data_access.config["DATA_DIR"] / Path(
+        "imap/spice/spk/imap_pred_20251002_20251113_v01.bsp"
+    )
+    assert ephem_file.spice_metadata["type"] == "ephemeris_predicted"
+
 
 def test_spice_extract_dps_pointing_parts():
     """Test the new DPS pointing kernel filename parsing."""


### PR DESCRIPTION
# Change Summary

## Overview

The MOC has been delivering od123 in the filename to better track their OD solutions with the ephemeris provided. We can handle this by adding in an optional group to match against that.

closes #281