### PR TITLE
Minor API Key Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ To use the API Key you can set the `IMAP_API_KEY` environment variable and then 
 the tool as usual.
 
 ```bash
-$ IMAP_API_KEY=<your-api-key> 
+$ IMAP_API_KEY=<your-api-key>
 $ imap-data-access ...
 ```
 


### PR DESCRIPTION
# Change Summary

## Overview
In the documentation for setting the API Key, I moved the environment variable setting step to a line before using the `imap-data-access`, so it's more clear that it's not part of the `imap-data-access` command. I also added `export` for setting the environment variable