### PR TITLE
ENH: adding config with data levels and descript for imap mission

### DIFF
--- a/imap_data_access/__init__.py
+++ b/imap_data_access/__init__.py
@@ -28,6 +28,7 @@ from imap_data_access.processing_input import (
     SPICEInput,
     SpinInput,
 )
+from imap_data_access.utils import ImapProductCatalog
 
 __all__ = [
     "VALID_DATALEVELS",
@@ -37,6 +38,7 @@ __all__ = [
     "CadenceFilePath",
     "DependencyFilePath",
     "ImapFilePath",
+    "ImapProductCatalog",
     "ProcessingInputCollection",
     "QuicklookFilePath",
     "ReleaseFilePath",
@@ -101,26 +103,7 @@ VALID_INSTRUMENTS = {
     "ultra",
 }
 
-VALID_DATALEVELS = {
-    "l0",
-    "l1",
-    "l1a",
-    "l1b",
-    "l1c",
-    "l1ca",
-    "l1cb",
-    "l1d",
-    "l2",
-    "l2a",
-    "l2b",
-    "l2c",
-    "l3",
-    "l3a",
-    "l3b",
-    "l3c",
-    "l3d",
-    "l3e",
-}
+VALID_DATALEVELS = ImapProductCatalog().data_levels()
 
 VALID_TABLES = {
     "science",

--- a/imap_data_access/imap_products_hierarchy.json
+++ b/imap_data_access/imap_products_hierarchy.json
@@ -1,0 +1,749 @@
+{
+  "science": {
+    "codice": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "hi-counters-aggregated",
+        "hi-counters-singles",
+        "hi-omni",
+        "hi-priority",
+        "hi-sectored",
+        "lo-counters-aggregated",
+        "lo-counters-singles",
+        "lo-nsw-priority",
+        "lo-sw-priority",
+        "lo-sw-species"
+      ],
+      "l1b": [
+        "hi-counters-aggregated",
+        "hi-counters-singles",
+        "hi-omni",
+        "hi-priority",
+        "hi-sectored",
+        "lo-counters-aggregated",
+        "lo-counters-singles",
+        "lo-nsw-priority",
+        "lo-sw-priority",
+        "lo-sw-species"
+      ],
+      "l2": [
+        "hi-direct-events",
+        "hi-omni",
+        "hi-sectored",
+        "lo-direct-events",
+        "lo-sw-species"
+      ],
+      "l3a": [
+        "hi-direct-events",
+        "lo-direct-events",
+        "lo-heplus-3d-distribution",
+        "lo-heplusplus-3d-distribution",
+        "lo-hplus-3d-distribution",
+        "lo-oplus6-3d-distribution",
+        "lo-partial-densities",
+        "lo-sw-charge-state-distributions",
+        "lo-sw-ratios"
+      ],
+      "l3b": [
+        "hi-pitch-angle"
+      ]
+    },
+    "glows": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "de",
+        "hist"
+      ],
+      "l1b": [
+        "de",
+        "hist"
+      ],
+      "l2": [
+        "hist"
+      ],
+      "l3a": [
+        "hist"
+      ],
+      "l3b": [
+        "ion-rate-profile"
+      ],
+      "l3c": [
+        "sw-profile"
+      ],
+      "l3d": [
+        "solar-hist"
+      ],
+      "l3e": [
+        "survival-probability-hi-45",
+        "survival-probability-hi-90",
+        "survival-probability-lo",
+        "survival-probability-ul-hf",
+        "survival-probability-ul-sf"
+      ]
+    },
+    "hi": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "45sensor-de",
+        "45sensor-diagfee",
+        "45sensor-hist",
+        "45sensor-hk",
+        "45sensor-memdmp",
+        "90sensor-de",
+        "90sensor-diagfee",
+        "90sensor-hist",
+        "90sensor-hk",
+        "90sensor-memdmp"
+      ],
+      "l1b": [
+        "45sensor-de",
+        "45sensor-goodtimes",
+        "45sensor-hk",
+        "90sensor-de",
+        "90sensor-goodtimes",
+        "90sensor-hk"
+      ],
+      "l1c": [
+        "45sensor-pset",
+        "90sensor-pset"
+      ],
+      "l2": [
+        "h45-ena-h-hf-nsp-anti-hae-4deg-1yr",
+        "h45-ena-h-hf-nsp-anti-hae-4deg-6mo",
+        "h45-ena-h-hf-nsp-anti-hae-6deg-1yr",
+        "h45-ena-h-hf-nsp-anti-hae-6deg-6mo",
+        "h45-ena-h-hf-nsp-full-hae-4deg-3mo",
+        "h45-ena-h-hf-nsp-full-hae-4deg-6mo",
+        "h45-ena-h-hf-nsp-full-hae-6deg-3mo",
+        "h45-ena-h-hf-nsp-full-hae-6deg-6mo",
+        "h45-ena-h-hf-nsp-ram-hae-4deg-1yr",
+        "h45-ena-h-hf-nsp-ram-hae-4deg-6mo",
+        "h45-ena-h-hf-nsp-ram-hae-6deg-1yr",
+        "h45-ena-h-hf-nsp-ram-hae-6deg-6mo",
+        "h45-ena-h-sf-nsp-anti-hae-4deg-1yr",
+        "h45-ena-h-sf-nsp-anti-hae-4deg-6mo",
+        "h45-ena-h-sf-nsp-anti-hae-6deg-1yr",
+        "h45-ena-h-sf-nsp-anti-hae-6deg-6mo",
+        "h45-ena-h-sf-nsp-full-hae-4deg-3mo",
+        "h45-ena-h-sf-nsp-full-hae-4deg-6mo",
+        "h45-ena-h-sf-nsp-full-hae-6deg-3mo",
+        "h45-ena-h-sf-nsp-full-hae-6deg-6mo",
+        "h45-ena-h-sf-nsp-ram-hae-4deg-1yr",
+        "h45-ena-h-sf-nsp-ram-hae-4deg-6mo",
+        "h45-ena-h-sf-nsp-ram-hae-6deg-1yr",
+        "h45-ena-h-sf-nsp-ram-hae-6deg-6mo",
+        "h90-ena-h-hf-nsp-anti-hae-4deg-1yr",
+        "h90-ena-h-hf-nsp-anti-hae-4deg-6mo",
+        "h90-ena-h-hf-nsp-anti-hae-6deg-1yr",
+        "h90-ena-h-hf-nsp-anti-hae-6deg-6mo",
+        "h90-ena-h-hf-nsp-full-hae-4deg-3mo",
+        "h90-ena-h-hf-nsp-full-hae-4deg-6mo",
+        "h90-ena-h-hf-nsp-full-hae-6deg-3mo",
+        "h90-ena-h-hf-nsp-full-hae-6deg-6mo",
+        "h90-ena-h-hf-nsp-ram-hae-4deg-1yr",
+        "h90-ena-h-hf-nsp-ram-hae-4deg-6mo",
+        "h90-ena-h-hf-nsp-ram-hae-6deg-1yr",
+        "h90-ena-h-hf-nsp-ram-hae-6deg-6mo",
+        "h90-ena-h-sf-nsp-anti-hae-4deg-1yr",
+        "h90-ena-h-sf-nsp-anti-hae-4deg-6mo",
+        "h90-ena-h-sf-nsp-anti-hae-6deg-1yr",
+        "h90-ena-h-sf-nsp-anti-hae-6deg-6mo",
+        "h90-ena-h-sf-nsp-full-hae-4deg-3mo",
+        "h90-ena-h-sf-nsp-full-hae-4deg-6mo",
+        "h90-ena-h-sf-nsp-full-hae-6deg-3mo",
+        "h90-ena-h-sf-nsp-full-hae-6deg-6mo",
+        "h90-ena-h-sf-nsp-ram-hae-4deg-1yr",
+        "h90-ena-h-sf-nsp-ram-hae-4deg-6mo",
+        "h90-ena-h-sf-nsp-ram-hae-6deg-1yr",
+        "h90-ena-h-sf-nsp-ram-hae-6deg-6mo"
+      ],
+      "l3": [
+        "h45-ena-h-hf-sp-anti-hae-4deg-1yr",
+        "h45-ena-h-hf-sp-anti-hae-6deg-1yr",
+        "h45-ena-h-hf-sp-full-hae-4deg-6mo",
+        "h45-ena-h-hf-sp-full-hae-6deg-6mo",
+        "h45-ena-h-hf-sp-ram-hae-4deg-1yr",
+        "h45-ena-h-hf-sp-ram-hae-6deg-1yr",
+        "h45-ena-h-sf-sp-anti-hae-4deg-1yr",
+        "h45-ena-h-sf-sp-anti-hae-6deg-1yr",
+        "h45-ena-h-sf-sp-ram-hae-4deg-1yr",
+        "h45-ena-h-sf-sp-ram-hae-6deg-1yr",
+        "h45-spx-h-hf-sp-anti-hae-4deg-1yr",
+        "h45-spx-h-hf-sp-anti-hae-6deg-1yr",
+        "h45-spx-h-hf-sp-full-hae-4deg-6mo",
+        "h45-spx-h-hf-sp-full-hae-6deg-6mo",
+        "h45-spx-h-hf-sp-ram-hae-4deg-1yr",
+        "h45-spx-h-hf-sp-ram-hae-6deg-1yr",
+        "h90-ena-h-hf-sp-anti-hae-4deg-1yr",
+        "h90-ena-h-hf-sp-anti-hae-6deg-1yr",
+        "h90-ena-h-hf-sp-full-hae-4deg-6mo",
+        "h90-ena-h-hf-sp-full-hae-6deg-6mo",
+        "h90-ena-h-hf-sp-ram-hae-4deg-1yr",
+        "h90-ena-h-hf-sp-ram-hae-6deg-1yr",
+        "h90-ena-h-sf-sp-anti-hae-4deg-1yr",
+        "h90-ena-h-sf-sp-anti-hae-6deg-1yr",
+        "h90-ena-h-sf-sp-full-hae-4deg-6mo",
+        "h90-ena-h-sf-sp-full-hae-6deg-6mo",
+        "h90-ena-h-sf-sp-ram-hae-4deg-1yr",
+        "h90-ena-h-sf-sp-ram-hae-6deg-1yr",
+        "h90-spx-h-hf-sp-anti-hae-4deg-1yr",
+        "h90-spx-h-hf-sp-anti-hae-6deg-1yr",
+        "h90-spx-h-hf-sp-full-hae-4deg-6mo",
+        "h90-spx-h-hf-sp-full-hae-6deg-6mo",
+        "h90-spx-h-hf-sp-ram-hae-4deg-1yr",
+        "h90-spx-h-hf-sp-ram-hae-6deg-1yr",
+        "hic-ena-h-hf-nsp-full-hae-4deg-1yr",
+        "hic-ena-h-hf-nsp-full-hae-6deg-1yr",
+        "hic-ena-h-hf-sp-full-hae-4deg-1yr",
+        "hic-ena-h-hf-sp-full-hae-6deg-1yr",
+        "hic-spx-h-hf-sp-full-hae-4deg-1yr",
+        "hic-spx-h-hf-sp-full-hae-6deg-1yr"
+      ]
+    },
+    "hit": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "counts-sectored",
+        "counts-standard"
+      ],
+      "l1b": [
+        "hk",
+        "sectored-rates",
+        "standard-rates",
+        "summed-rates"
+      ],
+      "l2": [
+        "macropixel-intensity",
+        "standard-intensity",
+        "summed-intensity"
+      ],
+      "l3": [
+        "direct-events",
+        "macropixel"
+      ]
+    },
+    "idex": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "msg-10days",
+        "sci-10days"
+      ],
+      "l1b": [
+        "msg-10days",
+        "sci-10days"
+      ],
+      "l2a": [
+        "sci-10days"
+      ],
+      "l2b": [
+        "sci-1mo"
+      ]
+    },
+    "lo": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "de",
+        "histogram",
+        "nhk",
+        "shk",
+        "spin",
+        "star"
+      ],
+      "l1b": [
+        "badtimes",
+        "bgrates",
+        "de",
+        "derates",
+        "goodtimes",
+        "histrates",
+        "instrument-status-summary",
+        "monitorrates",
+        "nhk",
+        "prostar",
+        "shk"
+      ],
+      "l1c": [
+        "pset"
+      ],
+      "l2": [
+        "l090-ena-h-hf-nsp-ram-hae-6deg-1yr",
+        "l090-ena-h-hk-nsp-ram-hae-6deg-1yr",
+        "l090-ena-h-sf-nsp-ram-hae-6deg-1yr",
+        "l090-ena-o-sf-nsp-ram-hae-6deg-1yr",
+        "l090-isn-h-sf-nsp-ram-hae-6deg-1yr",
+        "l090-isn-o-sf-nsp-ram-hae-6deg-1yr",
+        "t090-ena-h-sf-nsp-ram-hae-6deg-1yr",
+        "t090-isn-h-sf-nsp-ram-hae-6deg-1yr",
+        "t090-isn-o-sf-nsp-ram-hae-6deg-1yr"
+      ],
+      "l3": [
+        "l090-ena-h-hf-sp-ram-hae-6deg-1yr",
+        "l090-ena-h-sf-sp-ram-hae-6deg-1yr",
+        "l090-isn-h-sf-nsp-ram-hae-6deg-1yr",
+        "l090-isn-o-sf-nsp-ram-hae-6deg-1yr",
+        "l090-spx-h-hf-nsp-ram-hae-6deg-1yr",
+        "l090-spx-h-hf-sp-ram-hae-6deg-1yr",
+        "l090-spx-h-sf-nsp-ram-hae-6deg-1yr",
+        "l090-spx-h-sf-sp-ram-hae-6deg-1yr",
+        "l090-spxnbs-h-hk-nsp-ram-hae-6deg-1yr",
+        "l090-spxnbs-h-sf-nsp-ram-hae-6deg-1yr"
+      ]
+    },
+    "mag": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "burst-magi",
+        "burst-mago",
+        "norm-magi",
+        "norm-mago"
+      ],
+      "l1b": [
+        "burst-magi",
+        "burst-mago",
+        "norm-magi",
+        "norm-mago"
+      ],
+      "l1c": [
+        "norm-magi",
+        "norm-mago"
+      ],
+      "l1d": [
+        "burst-dsrf",
+        "burst-gse",
+        "burst-rtn",
+        "burst-srf",
+        "norm-dsrf",
+        "norm-gse",
+        "norm-rtn",
+        "norm-srf"
+      ],
+      "l2": [
+        "burst-dsrf",
+        "burst-gse",
+        "burst-rtn",
+        "burst-srf",
+        "norm-dsrf",
+        "norm-gse",
+        "norm-rtn",
+        "norm-srf"
+      ]
+    },
+    "spacecraft": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "pointing-attitude",
+        "quaternions"
+      ]
+    },
+    "swapi": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "hk"
+      ],
+      "l1": [
+        "sci"
+      ],
+      "l1b": [
+        "hk"
+      ],
+      "l2": [
+        "sci"
+      ],
+      "l3a": [
+        "alpha-sw",
+        "proton-sw",
+        "pui-he"
+      ],
+      "l3b": [
+        "combined"
+      ]
+    },
+    "swe": {
+      "l0": [
+        "sci"
+      ],
+      "l1a": [
+        "cem-raw",
+        "hk",
+        "sci"
+      ],
+      "l1b": [
+        "sci"
+      ],
+      "l2": [
+        "sci"
+      ],
+      "l3": [
+        "sci"
+      ]
+    },
+    "ultra": {
+      "l0": [
+        "raw"
+      ],
+      "l1a": [
+        "45sensor-aux",
+        "45sensor-de",
+        "45sensor-params",
+        "45sensor-priority-1-de",
+        "45sensor-priority-2-de",
+        "45sensor-priority-3-de",
+        "45sensor-priority-4-de",
+        "45sensor-rates",
+        "90sensor-aux",
+        "90sensor-de",
+        "90sensor-params",
+        "90sensor-priority-1-de",
+        "90sensor-priority-2-de",
+        "90sensor-priority-3-de",
+        "90sensor-priority-4-de",
+        "90sensor-rates"
+      ],
+      "l1b": [
+        "45sensor-badtimes",
+        "45sensor-de",
+        "45sensor-extendedspin",
+        "45sensor-goodtimes",
+        "45sensor-priority-1-de",
+        "45sensor-priority-2-de",
+        "45sensor-priority-3-de",
+        "45sensor-priority-4-de",
+        "45sensor-status",
+        "90sensor-badtimes",
+        "90sensor-de",
+        "90sensor-extendedspin",
+        "90sensor-goodtimes",
+        "90sensor-priority-1-de",
+        "90sensor-priority-2-de",
+        "90sensor-priority-3-de",
+        "90sensor-priority-4-de",
+        "90sensor-status"
+      ],
+      "l1c": [
+        "45sensor-heliopset",
+        "45sensor-spacecraftpset",
+        "90sensor-heliopset",
+        "90sensor-spacecraftpset"
+      ],
+      "l2": [
+        "u45-ena-h-hf-nsp-full-hae-2deg-1yr",
+        "u45-ena-h-hf-nsp-full-hae-2deg-3mo",
+        "u45-ena-h-hf-nsp-full-hae-2deg-6mo",
+        "u45-ena-h-hf-nsp-full-hae-4deg-1yr",
+        "u45-ena-h-hf-nsp-full-hae-4deg-3mo",
+        "u45-ena-h-hf-nsp-full-hae-4deg-6mo",
+        "u45-ena-h-hf-nsp-full-hae-6deg-1yr",
+        "u45-ena-h-hf-nsp-full-hae-6deg-3mo",
+        "u45-ena-h-hf-nsp-full-hae-6deg-6mo",
+        "u45-ena-h-sf-nsp-full-hae-2deg-1yr",
+        "u45-ena-h-sf-nsp-full-hae-2deg-3mo",
+        "u45-ena-h-sf-nsp-full-hae-2deg-6mo",
+        "u45-ena-h-sf-nsp-full-hae-4deg-1yr",
+        "u45-ena-h-sf-nsp-full-hae-4deg-3mo",
+        "u45-ena-h-sf-nsp-full-hae-4deg-6mo",
+        "u45-ena-h-sf-nsp-full-hae-6deg-1yr",
+        "u45-ena-h-sf-nsp-full-hae-6deg-3mo",
+        "u45-ena-h-sf-nsp-full-hae-6deg-6mo",
+        "u90-ena-h-hf-nsp-full-hae-2deg-1yr",
+        "u90-ena-h-hf-nsp-full-hae-2deg-3mo",
+        "u90-ena-h-hf-nsp-full-hae-2deg-6mo",
+        "u90-ena-h-hf-nsp-full-hae-4deg-1yr",
+        "u90-ena-h-hf-nsp-full-hae-4deg-3mo",
+        "u90-ena-h-hf-nsp-full-hae-4deg-6mo",
+        "u90-ena-h-hf-nsp-full-hae-6deg-1yr",
+        "u90-ena-h-hf-nsp-full-hae-6deg-3mo",
+        "u90-ena-h-hf-nsp-full-hae-6deg-6mo",
+        "u90-ena-h-sf-nsp-full-hae-2deg-1yr",
+        "u90-ena-h-sf-nsp-full-hae-2deg-3mo",
+        "u90-ena-h-sf-nsp-full-hae-2deg-6mo",
+        "u90-ena-h-sf-nsp-full-hae-4deg-1yr",
+        "u90-ena-h-sf-nsp-full-hae-4deg-3mo",
+        "u90-ena-h-sf-nsp-full-hae-4deg-6mo",
+        "u90-ena-h-sf-nsp-full-hae-6deg-1yr",
+        "u90-ena-h-sf-nsp-full-hae-6deg-3mo",
+        "u90-ena-h-sf-nsp-full-hae-6deg-6mo"
+      ],
+      "l3": [
+        "u45-ena-h-hf-sp-full-hae-2deg-1yr",
+        "u45-ena-h-hf-sp-full-hae-2deg-3mo",
+        "u45-ena-h-hf-sp-full-hae-2deg-6mo",
+        "u45-ena-h-hf-sp-full-hae-4deg-1yr",
+        "u45-ena-h-hf-sp-full-hae-4deg-3mo",
+        "u45-ena-h-hf-sp-full-hae-4deg-6mo",
+        "u45-ena-h-hf-sp-full-hae-6deg-1yr",
+        "u45-ena-h-hf-sp-full-hae-6deg-3mo",
+        "u45-ena-h-hf-sp-full-hae-6deg-6mo",
+        "u45-ena-h-sf-sp-full-hae-2deg-1yr",
+        "u45-ena-h-sf-sp-full-hae-2deg-3mo",
+        "u45-ena-h-sf-sp-full-hae-2deg-6mo",
+        "u45-ena-h-sf-sp-full-hae-4deg-1yr",
+        "u45-ena-h-sf-sp-full-hae-4deg-3mo",
+        "u45-ena-h-sf-sp-full-hae-4deg-6mo",
+        "u45-ena-h-sf-sp-full-hae-6deg-1yr",
+        "u45-ena-h-sf-sp-full-hae-6deg-3mo",
+        "u45-ena-h-sf-sp-full-hae-6deg-6mo",
+        "u45-spx-h-hf-sp-full-hae-2deg-1yr",
+        "u45-spx-h-hf-sp-full-hae-2deg-3mo",
+        "u45-spx-h-hf-sp-full-hae-2deg-6mo",
+        "u45-spx-h-hf-sp-full-hae-4deg-1yr",
+        "u45-spx-h-hf-sp-full-hae-4deg-3mo",
+        "u45-spx-h-hf-sp-full-hae-4deg-6mo",
+        "u45-spx-h-hf-sp-full-hae-6deg-1yr",
+        "u45-spx-h-hf-sp-full-hae-6deg-3mo",
+        "u45-spx-h-hf-sp-full-hae-6deg-6mo",
+        "u90-ena-h-hf-sp-full-hae-2deg-1yr",
+        "u90-ena-h-hf-sp-full-hae-2deg-3mo",
+        "u90-ena-h-hf-sp-full-hae-2deg-6mo",
+        "u90-ena-h-hf-sp-full-hae-4deg-1yr",
+        "u90-ena-h-hf-sp-full-hae-4deg-3mo",
+        "u90-ena-h-hf-sp-full-hae-4deg-6mo",
+        "u90-ena-h-hf-sp-full-hae-6deg-1yr",
+        "u90-ena-h-hf-sp-full-hae-6deg-3mo",
+        "u90-ena-h-hf-sp-full-hae-6deg-6mo",
+        "u90-ena-h-sf-sp-full-hae-2deg-1yr",
+        "u90-ena-h-sf-sp-full-hae-2deg-3mo",
+        "u90-ena-h-sf-sp-full-hae-2deg-6mo",
+        "u90-ena-h-sf-sp-full-hae-4deg-1yr",
+        "u90-ena-h-sf-sp-full-hae-4deg-3mo",
+        "u90-ena-h-sf-sp-full-hae-4deg-6mo",
+        "u90-ena-h-sf-sp-full-hae-6deg-1yr",
+        "u90-ena-h-sf-sp-full-hae-6deg-3mo",
+        "u90-ena-h-sf-sp-full-hae-6deg-6mo",
+        "u90-spx-h-hf-sp-full-hae-2deg-1yr",
+        "u90-spx-h-hf-sp-full-hae-2deg-3mo",
+        "u90-spx-h-hf-sp-full-hae-2deg-6mo",
+        "u90-spx-h-hf-sp-full-hae-4deg-1yr",
+        "u90-spx-h-hf-sp-full-hae-4deg-3mo",
+        "u90-spx-h-hf-sp-full-hae-4deg-6mo",
+        "u90-spx-h-hf-sp-full-hae-6deg-1yr",
+        "u90-spx-h-hf-sp-full-hae-6deg-3mo",
+        "u90-spx-h-hf-sp-full-hae-6deg-6mo",
+        "ulc-ena-h-hf-nsp-full-hae-2deg-1yr",
+        "ulc-ena-h-hf-nsp-full-hae-2deg-3mo",
+        "ulc-ena-h-hf-nsp-full-hae-2deg-6mo",
+        "ulc-ena-h-hf-nsp-full-hae-4deg-1yr",
+        "ulc-ena-h-hf-nsp-full-hae-4deg-3mo",
+        "ulc-ena-h-hf-nsp-full-hae-4deg-6mo",
+        "ulc-ena-h-hf-nsp-full-hae-6deg-1yr",
+        "ulc-ena-h-hf-nsp-full-hae-6deg-3mo",
+        "ulc-ena-h-hf-nsp-full-hae-6deg-6mo",
+        "ulc-ena-h-hf-sp-full-hae-2deg-1yr",
+        "ulc-ena-h-hf-sp-full-hae-2deg-3mo",
+        "ulc-ena-h-hf-sp-full-hae-2deg-6mo",
+        "ulc-ena-h-hf-sp-full-hae-4deg-1yr",
+        "ulc-ena-h-hf-sp-full-hae-4deg-3mo",
+        "ulc-ena-h-hf-sp-full-hae-4deg-6mo",
+        "ulc-ena-h-hf-sp-full-hae-6deg-1yr",
+        "ulc-ena-h-hf-sp-full-hae-6deg-3mo",
+        "ulc-ena-h-hf-sp-full-hae-6deg-6mo",
+        "ulc-spx-h-hf-sp-full-hae-2deg-1yr",
+        "ulc-spx-h-hf-sp-full-hae-2deg-3mo",
+        "ulc-spx-h-hf-sp-full-hae-2deg-6mo",
+        "ulc-spx-h-hf-sp-full-hae-4deg-1yr",
+        "ulc-spx-h-hf-sp-full-hae-4deg-3mo",
+        "ulc-spx-h-hf-sp-full-hae-4deg-6mo",
+        "ulc-spx-h-hf-sp-full-hae-6deg-1yr",
+        "ulc-spx-h-hf-sp-full-hae-6deg-3mo",
+        "ulc-spx-h-hf-sp-full-hae-6deg-6mo"
+      ]
+    }
+  },
+  "ancillary": {
+    "codice": [
+      "l1a-sci-lut",
+      "l2-hi-energy-table",
+      "l2-hi-omni-efficiency",
+      "l2-hi-sectored-efficiency",
+      "l2-hi-tof-table",
+      "l2-lo-efficiency",
+      "l2-lo-gfactor",
+      "l2-lo-onboard-energy-bins",
+      "l2-lo-onboard-energy-table",
+      "l2-lo-onboard-mpq-cal",
+      "lo-energy-per-charge",
+      "lo-mass-species-bin-lookup",
+      "mass-coefficient-lookup",
+      "mass-per-charge"
+    ],
+    "glows": [
+      "WawHelioIonMP",
+      "bad-days-list",
+      "calibration-data",
+      "conversion-table-for-anc-data",
+      "electron-density-2010a",
+      "energy-grid-hi",
+      "energy-grid-lo",
+      "energy-grid-ultra",
+      "exclusions-by-instr-team",
+      "ionization-files",
+      "lya-2010a",
+      "map-of-excluded-regions",
+      "map-of-extra-helio-bckgrd",
+      "map-of-uv-sources",
+      "photoion-2010a",
+      "pipeline-settings",
+      "pipeline-settings-l3bcde",
+      "plasma-speed-2010a",
+      "proton-density-2010a",
+      "suspected-transients",
+      "tess-xyz-8",
+      "time-dep-bckgrd",
+      "uv-anisotropy-1CR",
+      "uv-anisotropy-2010a",
+      "l1b-conversion-table-for-anc-data",
+      "l1b-exclusions-by-instr-team",
+      "l1b-map-of-excluded-regions",
+      "l1b-map-of-uv-sources",
+      "l1b-suspected-transients",
+      "l2-calibration",
+      "l3-map-of-extra-helio-bckgrd",
+      "l3-time-dep-bckgrd"
+    ],
+    "hi": [
+      "45sensor-cal-prod",
+      "45sensor-esa-energies",
+      "45sensor-esa-eta-fit-factors",
+      "90sensor-cal-prod",
+      "90sensor-esa-energies",
+      "90sensor-esa-eta-fit-factors",
+      "45sensor-backgrounds",
+      "90sensor-backgrounds"
+    ],
+    "hit": [
+      "hi-gain-lookup",
+      "hit-event-type-lookup",
+      "l1b-to-l2-macropixel-dt0-factors",
+      "l1b-to-l2-macropixel-dt1-factors",
+      "l1b-to-l2-macropixel-dt2-factors",
+      "l1b-to-l2-macropixel-dt3-factors",
+      "l1b-to-l2-standard-dt0-factors",
+      "l1b-to-l2-standard-dt1-factors",
+      "l1b-to-l2-standard-dt2-factors",
+      "l1b-to-l2-standard-dt3-factors",
+      "l1b-to-l2-summed-dt0-factors",
+      "l1b-to-l2-summed-dt1-factors",
+      "l1b-to-l2-summed-dt2-factors",
+      "l1b-to-l2-summed-dt3-factors",
+      "lo-gain-lookup",
+      "range-2A-charge-fit-lookup",
+      "range-2A-cosine-lookup",
+      "range-2B-charge-fit-lookup",
+      "range-2B-cosine-lookup",
+      "range-3A-charge-fit-lookup",
+      "range-3A-cosine-lookup",
+      "range-3B-charge-fit-lookup",
+      "range-3B-cosine-lookup",
+      "range-4A-charge-fit-lookup",
+      "range-4A-cosine-lookup",
+      "range-4B-charge-fit-lookup",
+      "range-4B-cosine-lookup"
+    ],
+    "idex": [
+      "l2a-calibration-curve-t-rise",
+      "l2a-calibration-curve-yield-params"
+    ],
+    "lo": [
+      "bad-times",
+      "esa-eta-fit-factors",
+      "esa-mode-lut",
+      "good-times",
+      "hydrogen-background",
+      "oxygen-background",
+      "sweep-table"
+    ],
+    "mag": [
+      "l1b-calibration",
+      "l1d-calibration",
+      "l2-burst-offsets",
+      "l2-calibration",
+      "l2-norm-offsets"
+    ],
+    "swapi": [
+      "alpha-density-temperature-lut",
+      "clock-angle-and-flow-deflection-lut",
+      "density-of-neutral-helium-lut",
+      "efficiency-lut",
+      "energy-gf-pui-lut",
+      "energy-gf-sw-lut",
+      "esa-unit-conversion",
+      "helium-inflow-vector",
+      "hydrogen-inflow-vector",
+      "instrument-response-lut",
+      "lut-notes",
+      "proton-density-temperature-lut",
+      "azimuthal-transmission",
+      "central-effective-area",
+      "passband-fit-coefficients"
+    ],
+    "swe": [
+      "config",
+      "esa-lut",
+      "eu-conversion",
+      "l1b-in-flight-cal"
+    ],
+    "ultra": [
+      "l1b-45sensor-back-pos-lookup",
+      "l1b-45sensor-imgparams-lookup",
+      "l1b-45sensor-leftslit-lookup",
+      "l1b-45sensor-logistic-interpolation",
+      "l1b-45sensor-rightslit-lookup",
+      "l1b-45sensor-spbtphcorr",
+      "l1b-45sensor-sptpphcorr",
+      "l1b-45sensor-tdc-norm-lookup",
+      "l1b-45sensor-tofxeflat",
+      "l1b-45sensor-tofxemedium",
+      "l1b-45sensor-tofxesteep",
+      "l1b-90sensor-back-pos-lookup",
+      "l1b-90sensor-imgparams-lookup",
+      "l1b-90sensor-leftslit-lookup",
+      "l1b-90sensor-rightslit-lookup",
+      "l1b-90sensor-scattering-calibration-data",
+      "l1b-90sensor-spbtphcorr",
+      "l1b-90sensor-sptpphcorr",
+      "l1b-90sensor-tdc-norm-lookup",
+      "l1b-90sensor-tofxeflat",
+      "l1b-90sensor-tofxemedium",
+      "l1b-90sensor-tofxesteep",
+      "l1b-egynorm-lookup",
+      "l1b-scattering-thresholds-per-energy",
+      "l1b-sensor-gf-blades",
+      "l1b-sensor-gf-noblades",
+      "l1b-tofxph",
+      "l1b-yadjust-lookup",
+      "l1c-45sensor-sc-pointing-bsf",
+      "l1c-45sensor-sc-pointing-index",
+      "l1c-45sensor-sc-pointing-phi",
+      "l1c-45sensor-sc-pointing-theta",
+      "l1c-45sensor-static-dead-times",
+      "l1c-90sensor-sc-pointing-bsf",
+      "l1c-90sensor-sc-pointing-index",
+      "l1c-90sensor-sc-pointing-phi",
+      "l1c-90sensor-sc-pointing-theta",
+      "l1c-90sensor-static-dead-times",
+      "ulc-spx-energy-ranges",
+      "l1b-45sensor-de-product-lookup",
+      "l1b-90sensor-de-product-lookup",
+      "l1b-90sensor-logistic-interpolation",
+      "l1c-45sensor-de-product-lookup",
+      "l1c-90sensor-de-product-lookup"
+    ]
+  }
+}

--- a/imap_data_access/imap_products_hierarchy.json
+++ b/imap_data_access/imap_products_hierarchy.json
@@ -247,6 +247,9 @@
       ],
       "l2b": [
         "sci-1mo"
+      ],
+      "l2c": [
+        "rectangular-map-1mo"
       ]
     },
     "lo": {

--- a/imap_data_access/utils.py
+++ b/imap_data_access/utils.py
@@ -1,6 +1,8 @@
 """Utility classes and enums for IMAP Data Access."""
 
+import json
 from enum import Enum
+from pathlib import Path
 
 
 class ReleaseType(Enum):
@@ -9,3 +11,103 @@ class ReleaseType(Enum):
     RELEASE = "release"
     EARLY_RELEASE = "early-release"
     UNRELEASE = "unrelease"
+
+
+class ImapProductCatalog:
+    """Provides structured lookups into the IMAP product hierarchy JSON.
+
+    The hierarchy JSON has two top-level sections:
+
+    ``science``
+        Maps  instrument -> data_level -> [descriptor, ...]
+
+    ``ancillary``
+        Maps  instrument -> [descriptor, ...]
+
+    Examples
+    --------
+    >>> pc = ImapProductCatalog()
+    >>> pc.data_levels()                            # all unique levels
+    >>> pc.data_levels("mag")                       # levels for mag
+    >>> pc.science_descriptors("mag", "l2")         # science descriptors for mag l2
+    >>> pc.ancillary_descriptors("hit")             # ancillary descriptors for hit
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        """Load and format dictionary for easier lookup."""
+        config_file = Path(__file__).parent / "imap_products_hierarchy.json"
+        with open(config_file, encoding="utf-8") as fp:
+            hierarchy = json.load(fp)
+        science_raw: dict[str, dict[str, list[str]]] = dict(
+            hierarchy.get("science", {})
+        )
+
+        # science: instrument -> data_level -> frozenset of descriptors
+        self._science: dict[str, dict[str, frozenset[str]]] = {
+            instrument: {
+                level: frozenset(descriptors) for level, descriptors in levels.items()
+            }
+            for instrument, levels in science_raw.items()
+        }
+
+        # ancillary: instrument -> frozenset of descriptors
+        self._ancillary: dict[str, frozenset[str]] = {
+            instrument: frozenset(descriptors)
+            for instrument, descriptors in hierarchy.get("ancillary", {}).items()
+        }
+
+        # pre-build the mission-wide level set (immutable)
+        self._all_levels: frozenset[str] = frozenset(
+            level for levels in self._science.values() for level in levels
+        )
+
+    def data_levels(self, instrument: str | None = None) -> tuple[str, ...]:
+        """Return sorted unique data levels for the mission or one instrument.
+
+        Parameters
+        ----------
+        instrument : str, optional
+            When omitted, returns all unique levels across every instrument.
+        """
+        if instrument is None:
+            return tuple(sorted(self._all_levels))
+        return tuple(sorted(self._science.get(instrument, {})))
+
+    def science_descriptors(
+        self,
+        instrument: str,
+        data_level: str | None = None,
+    ) -> tuple[str, ...]:
+        """Return sorted descriptors for an instrument, optionally filtered by level.
+
+        Parameters
+        ----------
+        instrument : str
+            Instrument name (e.g. ``"mag"``).
+        data_level : str, optional
+            When omitted, returns all descriptors across every level for the instrument.
+        """
+        instrument_levels = self._science.get(instrument, {})
+        if data_level is None:
+            return tuple(
+                sorted(
+                    {
+                        d
+                        for descriptors in instrument_levels.values()
+                        for d in descriptors
+                    }
+                )
+            )
+        return tuple(sorted(instrument_levels.get(data_level, frozenset())))
+
+    def ancillary_descriptors(self, instrument: str) -> tuple[str, ...]:
+        """Return sorted ancillary descriptor names for an instrument.
+
+        Parameters
+        ----------
+        instrument : str
+            Instrument name (e.g. ``"hit"``).
+        """
+        return tuple(sorted(self._ancillary.get(instrument, frozenset())))

--- a/imap_data_access/utils.py
+++ b/imap_data_access/utils.py
@@ -1,5 +1,7 @@
 """Utility classes and enums for IMAP Data Access."""
 
+from __future__ import annotations
+
 import json
 from enum import Enum
 from pathlib import Path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,62 @@
+from imap_data_access.utils import ImapProductCatalog
+
+
+def test_mission_data_levels():
+    """Test that we return expected data levels"""
+    product_catalog = ImapProductCatalog()
+    valid_datalevels = {
+        "l0",
+        "l1",
+        "l1a",
+        "l1b",
+        "l1c",
+        "l1d",
+        "l2",
+        "l2a",
+        "l2b",
+        "l3",
+        "l3a",
+        "l3b",
+        "l3c",
+        "l3d",
+        "l3e",
+    }
+    assert set(product_catalog.data_levels()) == valid_datalevels
+
+
+def test_instrument_data_levels():
+    """Test that we return expected data levels for an instrument"""
+    product_catalog = ImapProductCatalog()
+    print(product_catalog.data_levels("mag"))
+    assert set(product_catalog.data_levels("mag")) == {
+        "l0",
+        "l1a",
+        "l1b",
+        "l1c",
+        "l1d",
+        "l2",
+    }
+
+
+def test_science_descriptors():
+    """Test that we return expected science descriptors for an instrument and level"""
+    product_catalog = ImapProductCatalog()
+    print(product_catalog.science_descriptors("swe", "l2"))
+    assert set(product_catalog.science_descriptors("swe", "l2")) == {"sci"}
+
+
+def test_ancillary_descriptors():
+    """Test that we return expected ancillary descriptors for an instrument"""
+    product_catalog = ImapProductCatalog()
+    print(product_catalog.ancillary_descriptors("hi"))
+    hi_ancillary_expected = {
+        "45sensor-cal-prod",
+        "45sensor-esa-energies",
+        "45sensor-esa-eta-fit-factors",
+        "90sensor-cal-prod",
+        "90sensor-esa-energies",
+        "90sensor-esa-eta-fit-factors",
+        "45sensor-backgrounds",
+        "90sensor-backgrounds",
+    }
+    assert set(product_catalog.ancillary_descriptors("hi")) == hi_ancillary_expected


### PR DESCRIPTION
# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
We have been getting more frequent updates to website drop-down menu selections. It's been hard to track changes and pass information to web team.

We have been meaning to add valid data levels and descriptor for each instrument once it's finalized. We couldn't before but now may be good time to add these finalized information. I am hopeful that it will change less frequent in the future.

I updated on this repo and library since web team may be using this already. Repo `sds-data-manager` is too big and irrelevant to web team and other users.

With this update, website team can update `imap-data-access` version and call these new class methods to get valid data levels, descriptors for each data levels and ancillary descriptor and etc.

## File changes
<!--Add a list or paragraph describing the purpose/function of the changes.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- added json config file with tree of science and ancillary descriptors.
- add function to read in those information based on use cases for website and may be more users.

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
