### PR TITLE
Fix for failing tests

### DIFF
--- a/tests/test_config_options.py
+++ b/tests/test_config_options.py
@@ -31,8 +31,14 @@ def test_configuration_updates(config_var, default, expected):
         f"import imap_data_access; print(imap_data_access.config['{config_var}'])",
     ]
     # Default case
+    # Strip any IMAP_ overrides from the current environment so the built-in
+    # default is what gets used in `subprocess.run`.
+    default_env = {
+        key: value for key, value in os.environ.items() if f"IMAP_{config_var}" != key
+    }
     proc = subprocess.run(
         command,
+        env=default_env,
         capture_output=True,
         check=True,
         text=True,


### PR DESCRIPTION
Closes #327

The tests are assuming that they will always be run in an environment where the tested `IMAP_*` environment variables are unset. This might be true for the CI, but not true for the general development environment used for testing.

This fix omits any `IMAP_*` that are set in the host environment from being used in `subprocess.run`.