### PR TITLE
Add major/minor version querying to the query subtree

### DIFF
--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -227,6 +227,8 @@ def _query_parser(args: argparse.Namespace):
         "ingestion_end_date",
         "repointing",
         "version",
+        "major_version",
+        "minor_version",
         "extension",
         "filename",
         "type",
@@ -431,10 +433,24 @@ def add_query_args(subparser: ArgumentParser) -> None:
         "--version",
         type=str,
         required=False,
-        help="Version of the product in the format 'v001'."
+        help="Version of the product. Use 'v000' for a minor version or "
+        "'v000.0000' for a full major.minor version."
         " Must have one other parameter to run."
         " Passing 'latest' will return latest version of a file "
         "per dataset (instrument, data_level, descriptor) and day or repointing",
+    )
+    subparser.add_argument(
+        "--major-version",
+        type=str,
+        required=False,
+        help="Science major version to filter on (e.g. '1'). When omitted, "
+        "science queries default to the latest major version.",
+    )
+    subparser.add_argument(
+        "--minor-version",
+        type=str,
+        required=False,
+        help="Science minor version to filter on (e.g. '2').",
     )
     subparser.add_argument(
         "--extension", type=str, required=False, help="File extension (cdf, pkts)"

--- a/imap_data_access/cli.py
+++ b/imap_data_access/cli.py
@@ -27,6 +27,7 @@ import imap_data_access
 from imap_data_access.file_validation import (
     AncillaryFilePath,
     ScienceFilePath,
+    Version,
     generate_imap_file_path,
 )
 from imap_data_access.io import query, release, spice_query
@@ -47,6 +48,19 @@ def _download_parser(args: argparse.Namespace):
 
 
 # ruff: noqa: PLR0912, PLR0915
+def _format_science_version(item: dict) -> str:
+    """Build a combined version display string for a science result.
+
+    Science responses carry separate ``major_version`` / ``minor_version``
+    columns; render them as a single ``vMMM.mmmm`` string. Falls back to a
+    legacy ``version`` value if present.
+    """
+    minor = item.get("minor_version")
+    if minor is None:
+        return str(item.get("version", ""))
+    return str(Version(item.get("major_version"), minor))
+
+
 def _print_query_results_table(query_results: list[dict]):
     """Print the query results in a table.
 
@@ -69,6 +83,12 @@ def _print_query_results_table(query_results: list[dict]):
         query_table = "ancillary"
     elif "repointing" in query_results[0]:
         query_table = "science"
+
+    # Science responses split version into major/minor; synthesize a combined
+    # 'version' value so the width calc and printing can treat it as one column.
+    if query_table == "science":
+        for item in query_results:
+            item["version"] = _format_science_version(item)
 
     # Use the query_results for the header
     headers_science = [

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -125,7 +125,7 @@ def download(file_path: Union[Path, str]) -> Path:
 
 
 # Too many branches (16 >12)
-# ruff: noqa: PLR0912
+# ruff: noqa: PLR0912, PLR0915
 def _validate_query_parameters(**kwargs) -> None:
     """Validate all parameters used in the query function.
 
@@ -213,6 +213,15 @@ def _validate_query_parameters(**kwargs) -> None:
         version
     ):
         raise ValueError("Not a valid version, use format 'vXXX'.")
+
+    # Check the explicit major/minor version params (science only). Omit
+    # major_version entirely to get the latest major version.
+    major_version = kwargs.get("major_version")
+    minor_version = kwargs.get("minor_version")
+    if major_version is not None and not str(major_version).isdigit():
+        raise ValueError("Not a valid major_version, use an integer.")
+    if minor_version is not None and not str(minor_version).isdigit():
+        raise ValueError("Not a valid minor_version, use an integer.")
 
     # check extension
     if extension is not None:
@@ -309,6 +318,8 @@ def query(
     ingestion_end_date: Optional[str] = None,
     repointing: Optional[Union[str, int]] = None,
     version: Optional[str] = None,
+    major_version: Optional[Union[str, int]] = None,
+    minor_version: Optional[Union[str, int]] = None,
     extension: Optional[str] = None,
 ) -> list[dict[str, str]]:
     """Query the data archive for files matching the parameters.
@@ -344,7 +355,16 @@ def query(
     repointing : str, optional
         Repointing string, in the format 'repoint00000'.
     version : str, optional
-        Data version in the format ``vXXX`` or 'latest'.
+        Science data version in the format ``vMMM.mmmm`` (full) or the
+        deprecated minor-only ``vXXX``. ``latest`` returns the latest version
+        of a file per dataset. For science files this is a convenience that maps
+        to ``minor_version`` (and ``major_version`` for the full form);
+        prefer ``major_version`` / ``minor_version`` for new code.
+    major_version : str or int, optional
+        Science major version to filter on. When omitted, science queries
+        default to the latest major version (with all of its minor versions).
+    minor_version : str or int, optional
+        Science minor version to filter on.
     extension : str, optional
         File extension (``cdf``, ``pkts``)
 

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -378,12 +378,15 @@ def query(
     query_params = {key: value for key, value in locals().items() if value is not None}
     logger.debug("Input query parameters: %s", query_params)
 
-    # removing version from query if it is 'latest',
-    # ensuring other parameters are passed
-    if version == "latest":
+    # the science table is resolved server-side via a
+    # `latest=true` flag (mirrors spice_query); other tables are still filtered
+    # client-side after the query.
+    # Server-side filtering reduces the server errors seen by users when queries return
+    # too much data.
+    request_latest = version == "latest"
+    science_latest = request_latest and table == "science"
+    if request_latest:
         del query_params["version"]
-        if not query_params:
-            raise ValueError("One other parameter must be run with 'version'")
 
     # Copy params and remove table to ensure one other param was passed
     non_table_params = query_params.copy()
@@ -404,6 +407,10 @@ def query(
         else:
             query_params["repointing"] = int(repointing)
 
+    # Let the server resolve 'latest' for science instead of filtering here.
+    if science_latest:
+        query_params["latest"] = "true"
+
     url = f"{_get_base_url()}/query"
     request = requests.Request(method="GET", url=url, params=query_params).prepare()
 
@@ -413,8 +420,8 @@ def query(
         items = response.json()
         logger.debug("Received JSON: %s", items)
 
-    # if latest version was included in search then filter returned query for largest.
-    if (version == "latest") and items:
+    # Non-science tables still resolve 'latest' client-side
+    if request_latest and not science_latest and items:
 
         def get_key(file_entry):
             return (
@@ -434,6 +441,7 @@ def query(
             ):
                 latest_files[key] = item
         items = list(latest_files.values())
+
     return items
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -384,22 +384,15 @@ codice_ancillary_day2_v1 = {
 
 
 @pytest.mark.parametrize(
-    ("query_params", "query_results", "expected_filtered_results"),
+    ("query_params", "query_results"),
     [
         (
             {"instrument": "glows", "data_level": "l3e", "version": "latest"},
-            [glows_l3e_hi_repoint1, glows_l3e_hi_repoint2_v1, glows_l3e_hi_repoint2_v2],
-            [glows_l3e_hi_repoint1, glows_l3e_hi_repoint2_v2],
-        ),
-        (
-            {"instrument": "glows", "data_level": "l3e"},
-            [glows_l3e_hi_repoint1, glows_l3e_hi_repoint2_v1, glows_l3e_hi_repoint2_v2],
             [glows_l3e_hi_repoint1, glows_l3e_hi_repoint2_v1, glows_l3e_hi_repoint2_v2],
         ),
         (
             {"instrument": "swapi", "data_level": "l3b", "version": "latest"},
             [swapi_l3b_day1_v2, swapi_l3b_day2_v2, swapi_l3b_day2_v3],
-            [swapi_l3b_day1_v2, swapi_l3b_day2_v3],
         ),
         (
             {"start_date": "20250101", "end_date": "20250103", "version": "latest"},
@@ -409,13 +402,45 @@ codice_ancillary_day2_v1 = {
                 hi_l1c_45_day1_v1,
                 hi_l1c_90_day1_v1,
             ],
-            [
-                hi_l1b_45_day1_v1,
-                lo_l1c_45_day1_v1,
-                hi_l1c_45_day1_v1,
-                hi_l1c_90_day1_v1,
-            ],
         ),
+    ],
+)
+def test_query_science_latest_resolved_server_side(
+    mock_send_request,
+    query_params: dict,
+    query_results: list[dict],
+):
+    """Science `version=latest` is resolved server-side, not client-side.
+
+    The client must forward a ``latest=true`` flag (dropping the ``version``
+    param) and return the server's results without any client-side filtering.
+
+    Parameters
+    ----------
+    mock_send_request : unittest.mock.MagicMock
+        Mock object for requests.Session
+    query_params : dict
+        Dictionary of key/value pairs that set the query parameters
+    query_results : list[dict]
+        Result returned by the query API call
+    """
+    mock_response = MagicMock()
+    mock_response.json.return_value = query_results
+    mock_send_request.return_value = mock_response
+
+    response = imap_data_access.query(**query_params)
+    # No client-side filtering: results pass through unchanged.
+    assert response == query_results
+
+    # The outgoing request carries latest=true and drops the version param.
+    sent_request = mock_send_request.call_args[0][0]
+    assert "latest=true" in sent_request.url
+    assert "version=" not in sent_request.url
+
+
+@pytest.mark.parametrize(
+    ("query_params", "query_results", "expected_filtered_results"),
+    [
         (
             {"table": "ancillary", "instrument": "codice", "version": "latest"},
             [
@@ -430,13 +455,16 @@ codice_ancillary_day2_v1 = {
         ),
     ],
 )
-def test_query_with_version_latest(
+def test_query_nonscience_latest_filtered_client_side(
     mock_send_request,
     query_params: dict,
     query_results: list[dict],
     expected_filtered_results: list[dict],
 ):
-    """Test Query version latest filtering.
+    """Non-science `version=latest` is still resolved client-side.
+
+    The server only resolves latest for science, so for other tables the client
+    keeps the highest-version file per dataset and does not send latest=true.
 
     Parameters
     ----------
@@ -445,7 +473,7 @@ def test_query_with_version_latest(
     query_params : dict
         Dictionary of key/value pairs that set the query parameters
     query_results : list[dict]
-        Result returned by query API call
+        Result returned by the query API call
     expected_filtered_results : list[dict]
         The expected results after latest version filtering
     """
@@ -455,6 +483,10 @@ def test_query_with_version_latest(
 
     response = imap_data_access.query(**query_params)
     assert response == expected_filtered_results
+
+    # The client does not delegate latest for non-science tables.
+    sent_request = mock_send_request.call_args[0][0]
+    assert "latest=true" not in sent_request.url
 
 
 def test_query_no_params(mock_send_request):
@@ -635,36 +667,23 @@ def test_bad_query_input(query_flag, query_input, expected_output):
 
 
 @pytest.mark.parametrize(
-    ("items", "latest_version"),
+    "items",
     [
-        (
-            [
-                {"minor_version": 1},
-                {"minor_version": 1},
-                {
-                    "minor_version": 2,
-                },  # This should be considered the latest version
-            ],
-            2,
-        ),
-        (
-            [
-                {"minor_version": 1},
-                {"minor_version": 100},
-            ],
-            100,
-        ),
+        [{"minor_version": 1}, {"minor_version": 1}, {"minor_version": 2}],
+        [{"minor_version": 1}, {"minor_version": 100}],
     ],
 )
-def test_query_latest_version(mock_send_request, items: list, latest_version: str):
-    """
-    Test a function call to query with the latest version flag.
+def test_query_latest_version(mock_send_request, items: list):
+    """Science `version=latest` is delegated to the server, not filtered here.
+
+    The client sends ``latest=true`` (dropping ``version``) and returns the
+    server's results unchanged; choosing the latest is the server's job.
 
     Parameters
     ----------
     mock_send_request : unittest.mock.MagicMock
         Mock object for requests.Session
-    items : dict
+    items : list
         List of query response items.
     """
     query_params = {
@@ -687,13 +706,18 @@ def test_query_latest_version(mock_send_request, items: list, latest_version: st
         "descriptor": "test-description",
         "start_date": "20100101",
     }
-    mock_response.json.return_value = [i | base_items for i in items]
+    expected_items = [i | base_items for i in items]
+    mock_response.json.return_value = expected_items
     mock_send_request.return_value = mock_response
 
     response = imap_data_access.query(**query_params)
-    # There should be one item returned
-    assert len(response) == 1
-    assert response[0]["minor_version"] == latest_version
+    # Results pass through unchanged: the server resolves 'latest'.
+    assert response == expected_items
+
+    # The request delegates via latest=true and drops the version param.
+    sent_request = mock_send_request.call_args[0][0]
+    assert "latest=true" in sent_request.url
+    assert "version=" not in sent_request.url
 
 
 def test_upload_no_file(mock_send_request):


### PR DESCRIPTION
## Summary
Updates the query client and CLI to match the science version-scheme rework (major/minor split) and the new query API. Adds explicit major/minor version parameters and documents the full `vMMM.mmmm` version format.

Also moves the "latest" version filtering to the server side (in matching sds-data-manager PR) to try and reduce the server errors users see when query returns too many files.

## Changes
- **`io.query()`**: new `major_version` and `minor_version` keyword arguments, passed through to the query API. Validated as integers; omitting `major_version` returns the latest major version (resolved server-side).
- **`--version` help/format**: now documents `v000` (minor-only) and `v000.0000` (full major.minor) forms.
- **New CLI flags**: `--major-version` and `--minor-version` on the `query` subcommand, wired into `query()`.
- Updated `_validate_query_parameters` and docstrings accordingly.

🤖 Co-created with [Claude Code](https://claude.com/claude-code)
