### PR TITLE
Remove deprecated vXXX handling for scienceFiles

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -387,7 +387,8 @@ class ScienceFilePath(ImapFilePath):
         data_level: str,
         descriptor: str,
         start_time: str,
-        version: str,
+        major_version: int | None,
+        minor_version: int,
         extension: str = "cdf",
         repointing: int | str | None = None,
         cr: int | None = None,
@@ -411,8 +412,11 @@ class ScienceFilePath(ImapFilePath):
             The data level for the filename
         start_time: str
             The start time for the filename
-        version : str
-            The version of the data
+        major_version : int | None
+            The major version of the data. If None, the version will be constructed
+             using the minor version in the legacy vXXX format.
+        minor_version : int
+            The minor version of the data
         extension : str, optional
             The extension type of the file. Default is "cdf"
             For l0 files, the extension is always "pkts"
@@ -443,9 +447,10 @@ class ScienceFilePath(ImapFilePath):
                 )
         if cr:
             time_field += f"-cr{cr:05d}"
+        version_str = str(Version(major_version, minor_version))
         filename = (
             f"imap_{instrument}_{data_level}_{descriptor}_{time_field}_"
-            f"{version}.{extension}"
+            f"{version_str}.{extension}"
         )
         return cls(filename)
 

--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -180,36 +180,35 @@ class Version:
         return Version.valid_imap_version_pattern
 
     @staticmethod
-    def is_valid_version(version: str) -> bool:
+    def is_valid_version(
+        version: str, pattern: str = valid_imap_version_pattern
+    ) -> bool:
         """Check if the version string has a valid format 'vXXX' or 'vMMM.mmmm'.
 
         Parameters
         ----------
         version : str
             Version string to check.
+        pattern : str, optional
+            Regex pattern to use for validation. Defaults to
+            valid_imap_version_pattern for version patterns vXXX or vMMM.mmmm.
 
         Returns
         -------
         bool
             Whether the version string is valid or not.
         """
-        return bool(re.fullmatch(Version.valid_imap_version_pattern, version))
+        return bool(re.fullmatch(pattern, version))
+
+    @staticmethod
+    def is_valid_science_version(version: str) -> bool:
+        """Check if the version string has a valid format 'vMMM.mmmm'."""
+        return Version.is_valid_version(version, Version.science_version_pattern)
 
     @staticmethod
     def is_valid_version_minor_only(version: str) -> bool:
-        """Check if the version string is in the valid minor-only format 'vXXX'.
-
-        Parameters
-        ----------
-        version : str
-            Version string to check.
-
-        Returns
-        -------
-        bool
-            Whether the version string is valid or not.
-        """
-        return bool(re.fullmatch(Version.minor_only_version_pattern, version))
+        """Check if the version string is in the valid minor-only format 'vXXX'."""
+        return Version.is_valid_version(version, Version.minor_only_version_pattern)
 
     @staticmethod
     def _validate_range(value: int, max_value: int) -> None:
@@ -233,6 +232,8 @@ class ImapFilePath:
     Includes shared static methods and provides correct typing for ScienceFilePath,
     AncillaryFilePath, and SPICEFilePath.
     """
+
+    VALID_VERSION_PATTERN: typing.ClassVar[str] = Version.minor_only_version_pattern
 
     class InvalidImapFileError(Exception):
         """Indicates a bad file type."""
@@ -276,9 +277,9 @@ class ImapFilePath:
         except ValueError:
             return False
 
-    @staticmethod
-    def is_valid_version(input_version: str) -> bool:
-        """Check input version string is in valid format 'vXXX' or 'latest'.
+    @classmethod
+    def is_valid_version(cls, input_version: str) -> bool:
+        """Check input version string is "latest" or the class's valid version pattern.
 
         Parameters
         ----------
@@ -290,8 +291,8 @@ class ImapFilePath:
         bool
             Whether input version is valid or not.
         """
-        return input_version == "latest" or Version.is_valid_version_minor_only(
-            input_version
+        return input_version == "latest" or Version.is_valid_version(
+            input_version, cls.VALID_VERSION_PATTERN
         )
 
     @abstractmethod
@@ -311,11 +312,10 @@ class ScienceFilePath(ImapFilePath):
     FILENAME_CONVENTION = (
         "<mission>_<instrument>_<datalevel>_<descriptor>_"
         "<startdate>(-<repointing>)_<version>.<extension>"
-        " where version is vMMM.mmmm (legacy vXXX is deprecated but supported)"
+        " where version is vMMM.mmmm (legacy vXXX is deprecated and no longer "
+        "supported.)"
     )
-    # TODO update this to be Version.science_version_pattern once files have been
-    #  renamed.
-    VALID_VERSION_PATTERN: typing.ClassVar[str] = Version.valid_imap_version_pattern
+    VALID_VERSION_PATTERN: typing.ClassVar[str] = Version.science_version_pattern
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "pkts"}
     _dir_prefix = "imap"
 
@@ -347,7 +347,7 @@ class ScienceFilePath(ImapFilePath):
         <cr>: This is an optional field describing the Carrington rotation.
             format: crXXXXX.
         <version>: This stores the data version for this product, format: vMMM.mmmm.
-            Legacy vXXX is accepted for backward compatibility but deprecated.
+            vXXX format is deprecated and will raise an error.
 
         Parameters
         ----------
@@ -371,7 +371,6 @@ class ScienceFilePath(ImapFilePath):
         self.start_date = split_filename["start_date"]
         self.repointing = split_filename["repointing"]
         self.cr = split_filename["cr"]
-        self.version = split_filename["version"]
         self.major_version = split_filename["major_version"]
         self.minor_version = split_filename["minor_version"]
         self.extension = split_filename["extension"]
@@ -476,8 +475,9 @@ class ScienceFilePath(ImapFilePath):
                 self.data_level,
                 self.descriptor,
                 self.start_date,
-                self.version,
                 self.extension,
+                self.major_version,
+                self.minor_version,
             ]
         ):
             error_message = (
@@ -501,11 +501,6 @@ class ScienceFilePath(ImapFilePath):
             )
         if not self.is_valid_date(self.start_date):
             error_message += "Invalid start date format. Please use YYYYMMDD format. \n"
-        if not ScienceFilePath.is_valid_version(self.version):
-            error_message += (
-                "Invalid version format. Please use vMMM.mmmm format"
-                " (vXXX format is deprecated but supported for compatibility).\n"
-            )
         if self.repointing and not isinstance(self.repointing, int):
             error_message += "The repointing number should be an integer.\n"
 
@@ -542,7 +537,8 @@ class ScienceFilePath(ImapFilePath):
         """Extract all components from filename. Does not validate instrument or level.
 
         Will return a dictionary with the following keys:
-        { instrument, datalevel, descriptor, startdate, enddate, version, extension, cr,
+        { instrument, datalevel, descriptor, startdate, enddate, major_version,
+        minor_version, extension, cr,
         repointing }
 
         If a match is not found, a ValueError will be raised.
@@ -599,7 +595,7 @@ class ScienceFilePath(ImapFilePath):
         del components["interval_type"]
 
         # Get major and minor versions
-        version = Version.from_version(components["version"])
+        version = Version.from_version(components.pop("version"))
         components["major_version"] = version.major
         components["minor_version"] = version.minor
 
@@ -654,15 +650,6 @@ class ScienceFilePath(ImapFilePath):
             Whether input carrington rotation is valid or not.
         """
         return re.fullmatch(r"cr\d{5}", str(input_cr))
-
-    @staticmethod
-    def is_valid_version(input_version: str) -> bool:
-        """Check input version string is valid for science files.
-
-        A valid science version is ``vMMM.mmmm`` or legacy ``vXXX``. The special value
-        ``latest`` is also accepted for query-style inputs.
-        """
-        return input_version == "latest" or Version.is_valid_version(input_version)
 
 
 # Transform the suffix to the directory structure we are using

--- a/imap_data_access/io.py
+++ b/imap_data_access/io.py
@@ -125,7 +125,7 @@ def download(file_path: Union[Path, str]) -> Path:
 
 
 # Too many branches (16 >12)
-# ruff: noqa: PLR0912, PLR0915
+# ruff: noqa: PLR0912
 def _validate_query_parameters(**kwargs) -> None:
     """Validate all parameters used in the query function.
 
@@ -201,14 +201,6 @@ def _validate_query_parameters(**kwargs) -> None:
                     " where <num> is a 5 digit integer."
                 ) from err
 
-    # Check version make sure to include 'latest'
-    if table == "science":
-        if version is not None and not file_validation.ScienceFilePath.is_valid_version(
-            version
-        ):
-            raise ValueError(
-                "Not a valid version, use format 'vMMM.mmmm' or 'vXXX' (deprecated)."
-            )
     elif version is not None and not file_validation.ImapFilePath.is_valid_version(
         version
     ):

--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -560,6 +560,7 @@ def _get_latest_version_file_path(
         descriptor="raw",
         start_time=start_time.strftime("%Y%m%d"),
         repointing=repointing,
-        version=latest_version,
+        major_version=0,
+        minor_version=max_minor_version,
     )
     return science_file.construct_path()

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -171,11 +171,9 @@ def test_construct_upload_path():
 
 def test_generate_from_inputs():
     """Tests the ``generate_from_inputs`` method."""
-    sfm = ScienceFilePath.generate_from_inputs(
-        "mag", "l1a", "burst", "20210101", "v001"
-    )
+    sfm = ScienceFilePath.generate_from_inputs("mag", "l1a", "burst", "20210101", 0, 1)
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_v001.cdf"
+        "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_v000.0001.cdf"
     )
 
     assert sfm.construct_path() == expected_output
@@ -184,12 +182,12 @@ def test_generate_from_inputs():
     assert sfm.descriptor == "burst"
     assert sfm.start_date == "20210101"
     assert sfm.repointing is None
-    assert sfm.version == "v001"
+    assert sfm.version == "v000.0001"
     assert sfm.extension == "cdf"
 
-    sfm = ScienceFilePath.generate_from_inputs("mag", "l0", "raw", "20210101", "v001")
+    sfm = ScienceFilePath.generate_from_inputs("mag", "l0", "raw", "20210101", 0, 1)
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/mag/l0/2021/01/imap_mag_l0_raw_20210101_v001.pkts"
+        "imap/mag/l0/2021/01/imap_mag_l0_raw_20210101_v000.0001.pkts"
     )
 
     assert sfm.construct_path() == expected_output
@@ -199,25 +197,26 @@ def test_generate_from_inputs():
         "l0",
         "raw",
         "20210101",
-        "v001",
+        0,
+        1,
         repointing=1,
     )
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/mag/l0/2021/01/imap_mag_l0_raw_20210101-repoint00001_v001.pkts"
+        "imap/mag/l0/2021/01/imap_mag_l0_raw_20210101-repoint00001_v000.0001.pkts"
     )
     assert sfm.construct_path() == expected_output
 
     sfm = ScienceFilePath.generate_from_inputs(
-        "glows", "l3a", "test", "20210101", "v001", cr=23
+        "glows", "l3a", "test", "20210101", 0, 1, cr=23
     )
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/glows/l3a/2021/01/imap_glows_l3a_test_20210101-cr00023_v001.cdf"
+        "imap/glows/l3a/2021/01/imap_glows_l3a_test_20210101-cr00023_v000.0001.cdf"
     )
     assert sfm.construct_path() == expected_output
 
     with pytest.raises(ImapFilePath.InvalidImapFileError):
         sfm = ScienceFilePath.generate_from_inputs(
-            "glows", "l3a", "test", "20210101", "v001", cr=23, repointing=1
+            "glows", "l3a", "test", "20210101", 0, 1, cr=23, repointing=1
         )
 
 
@@ -574,7 +573,8 @@ def test_deprecated_data_dir():
         "l1a",
         "burst",
         "20210101",
-        "v001",
+        0,
+        1,
     )
     with pytest.deprecated_call():
         assert imap_data_access.config["DATA_DIR"] == science_file.data_dir
@@ -588,7 +588,8 @@ def test_science_file_creation_data_dir(monkeypatch):
         "l1a",
         "burst",
         "20210101",
-        "v001",
+        0,
+        1,
     )
     # Typical case
     assert science_file.construct_path().is_relative_to(
@@ -615,7 +616,8 @@ def test_quicklook_file_path():
             data_level="l1a",
             descriptor="test",
             start_time="20210101",
-            version="v001",
+            major_version=0,
+            minor_version=1,
             extension="png",
         )
     # Test for an invalid quicklook file (incorrect extension type)
@@ -625,7 +627,8 @@ def test_quicklook_file_path():
             data_level="l1a",
             descriptor="test",
             start_time="20210101",
-            version="v001",
+            major_version=0,
+            minor_version=1,
             extension="cdf",
         )
 
@@ -635,11 +638,12 @@ def test_quicklook_file_path():
         data_level="l1a",
         descriptor="test",
         start_time="20210101",
-        version="v001",
+        major_version=0,
+        minor_version=1,
         extension="png",
     )
     expected_output_no_end_date = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/quicklook/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v001.png"
+        "imap/quicklook/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v000.0001.png"
     )
     assert file_no_repointing.construct_path() == expected_output_no_end_date
 
@@ -650,11 +654,12 @@ def test_quicklook_file_path():
         descriptor="test",
         start_time="20210101",
         repointing=1,
-        version="v001",
+        major_version=1,
+        minor_version=1,
         extension="png",
     )
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/quicklook/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v001.png"
+        "imap/quicklook/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v001.0001.png"
     )
     assert file_all_params.construct_path() == expected_output
 
@@ -673,7 +678,8 @@ def test_dependency_file_path():
             data_level="l1a",
             descriptor="test",
             start_time="20210101",
-            version="v001",
+            major_version=0,
+            minor_version=1,
             extension="json",
         )
     # Test for an invalid dependency file (incorrect extension type)
@@ -683,7 +689,8 @@ def test_dependency_file_path():
             data_level="l1a",
             descriptor="test",
             start_time="20210101",
-            version="v001",
+            major_version=0,
+            minor_version=1,
             extension="cdf",
         )
 
@@ -693,11 +700,12 @@ def test_dependency_file_path():
         data_level="l1a",
         descriptor="test",
         start_time="20210101",
-        version="v001",
+        major_version=0,
+        minor_version=1,
         extension="json",
     )
     expected_output_no_end_date = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/dependency/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v001.json"
+        "imap/dependency/mag/l1a/2021/01/imap_mag_l1a_test_20210101_v000.0001.json"
     )
     assert file_no_repointing.construct_path() == expected_output_no_end_date
 
@@ -708,11 +716,12 @@ def test_dependency_file_path():
         descriptor="test",
         start_time="20210101",
         repointing=1,
-        version="v001",
+        major_version=0,
+        minor_version=1,
         extension="json",
     )
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/dependency/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v001.json"
+        "imap/dependency/mag/l1a/2021/01/imap_mag_l1a_test_20210101-repoint00001_v000.0001.json"
     )
     assert file_all_params.construct_path() == expected_output
 

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -28,7 +28,6 @@ def test_extract_filename_components():
         "data_level": "l1a",
         "descriptor": "burst",
         "start_date": "20210101",
-        "version": "v001.0001",
         "major_version": 1,
         "minor_version": 1,
         "repointing": None,
@@ -68,29 +67,6 @@ def test_extract_filename_components():
     )
 
 
-# TODO remove this test after file versions are updated from vXXX to vRRR.MMM
-def test_extract_filename_components_deprecated_version_format():
-    """Tests the ``extract_filename_components` with old filename convention."""
-    valid_filename = "imap_mag_l1a_burst_20210101_v001.pkts"
-    # Use deprecated version format
-    expected_output = {
-        "mission": "imap",
-        "instrument": "mag",
-        "data_level": "l1a",
-        "descriptor": "burst",
-        "start_date": "20210101",
-        "major_version": None,
-        "minor_version": 1,
-        "repointing": None,
-        "cr": None,
-        "version": "v001",
-        "extension": "pkts",
-    }
-    assert (
-        ScienceFilePath.extract_filename_components(valid_filename) == expected_output
-    )
-
-
 def test_construct_sciencefilepathmanager():
     """Tests that the ``ScienceFilePath`` class constructs a valid filename."""
     valid_filename = "imap_mag_l1a_burst_20210101_v001.0001.cdf"
@@ -101,33 +77,32 @@ def test_construct_sciencefilepathmanager():
     assert sfm.descriptor == "burst"
     assert sfm.start_date == "20210101"
     assert sfm.repointing is None
-    assert sfm.version == "v001.0001"
     assert sfm.major_version == 1
     assert sfm.minor_version == 1
     assert sfm.extension == "cdf"
 
     # no extension
-    invalid_filename = "imap_mag_l1a_burst_20210101_v001"
+    invalid_filename = "imap_mag_l1a_burst_20210101_v001.0001"
     with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # invalid extension
-    invalid_filename = "imap_mag_l1a_burst_20210101_v001.abc"
+    invalid_filename = "imap_mag_l1a_burst_20210101_v001.0001.abc"
     with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # invalid instrument
-    invalid_filename = "imap_sdc_l1a_burst_20210101_v001.cdf"
+    invalid_filename = "imap_sdc_l1a_burst_20210101_v001.0001.cdf"
     with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # Bad repointing, not 5 digits
-    invalid_filename = "imap_mag_l1a_burst_20210101-repoint0001_v001.cdf"
+    invalid_filename = "imap_mag_l1a_burst_20210101-repoint0001_v001.0001.cdf"
     with pytest.raises(ScienceFilePath.InvalidImapFileError):
         ScienceFilePath(invalid_filename)
 
     # good path with an extra "test" directory
-    valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_v001.cdf")
+    valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_v001.0001.cdf")
     sfm = ScienceFilePath(valid_filepath)
 
     assert sfm.instrument == "mag"
@@ -135,7 +110,8 @@ def test_construct_sciencefilepathmanager():
     assert sfm.descriptor == "burst"
     assert sfm.start_date == "20210101"
     assert sfm.repointing is None
-    assert sfm.version == "v001"
+    assert sfm.major_version == 1
+    assert sfm.minor_version == 1
     assert sfm.extension == "cdf"
 
     # Test valid date for given start_date
@@ -160,10 +136,10 @@ def test_is_valid_date():
 
 def test_construct_upload_path():
     """Tests the ``construct_path`` method."""
-    valid_filename = "imap_mag_l1a_burst_20210101_v001.cdf"
+    valid_filename = "imap_mag_l1a_burst_20210101_v001.0001.cdf"
     sfm = ScienceFilePath(valid_filename)
     expected_output = imap_data_access.config["DATA_DIR"] / Path(
-        "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_v001.cdf"
+        "imap/mag/l1a/2021/01/imap_mag_l1a_burst_20210101_v001.0001.cdf"
     )
 
     assert sfm.construct_path() == expected_output
@@ -182,7 +158,8 @@ def test_generate_from_inputs():
     assert sfm.descriptor == "burst"
     assert sfm.start_date == "20210101"
     assert sfm.repointing is None
-    assert sfm.version == "v000.0001"
+    assert sfm.major_version == 0
+    assert sfm.minor_version == 1
     assert sfm.extension == "cdf"
 
     sfm = ScienceFilePath.generate_from_inputs("mag", "l0", "raw", "20210101", 0, 1)
@@ -664,7 +641,7 @@ def test_quicklook_file_path():
     assert file_all_params.construct_path() == expected_output
 
     # Test by passing the file
-    file = QuicklookFilePath("imap_mag_l1a_test_20210101_v001.png")
+    file = QuicklookFilePath("imap_mag_l1a_test_20210101_v001.0001.png")
     assert file.instrument == "mag"
     assert file.start_date == "20210101"
 
@@ -726,7 +703,7 @@ def test_dependency_file_path():
     assert file_all_params.construct_path() == expected_output
 
     # Test by passing the file
-    file = DependencyFilePath("imap_mag_l1a_test_20210101_v001.json")
+    file = DependencyFilePath("imap_mag_l1a_test_20210101_v000.0001.json")
     assert file.instrument == "mag"
     assert file.start_date == "20210101"
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -638,7 +638,7 @@ def test_spice_query_bad_params(mock_send_request):
             "Not a valid repointing, use format repoint<num>, "
             "where <num> is a 5 digit integer.",
         ),
-        ("version", "badInput", "Not a valid version, use format 'vMMM.mmmm."),
+        ("version", "badInput", "Not a valid version, use format 'vXXX"),
         (
             "extension",
             "badInput",

--- a/tests/test_processing_input.py
+++ b/tests/test_processing_input.py
@@ -59,9 +59,11 @@ def test_create_science_files():
 
 # TODO remove this test after file versions are updated from vXXX to vRRR.MMM
 def test_create_science_files_deprecated_version_format():
-    one_file = processing_input.ScienceInput("imap_mag_l1a_norm-magi_20240312_v000.cdf")
+    one_file = processing_input.ScienceInput(
+        "imap_mag_l1a_norm-magi_20240312_v000.0001.cdf"
+    )
 
-    assert one_file.filename_list == ["imap_mag_l1a_norm-magi_20240312_v000.cdf"]
+    assert one_file.filename_list == ["imap_mag_l1a_norm-magi_20240312_v000.0001.cdf"]
     assert len(one_file.imap_file_paths) == 1
     assert isinstance(one_file.imap_file_paths[0], ScienceFilePath)
 
@@ -315,7 +317,7 @@ def test_create_collection():  # noqa: PLR0915
 
     input_collection_str = [
         {"type": "spice", "files": ["naif0012.tls", "imap_sclk_0001.tsc"]},
-        {"type": "science", "files": ["imap_swe_l0_raw_20260924_v007.pkts"]},
+        {"type": "science", "files": ["imap_swe_l0_raw_20260924_v000.0007.pkts"]},
         {"type": "spin", "files": ["imap_1000_100_1000_100_01.spin.csv"]},
         {"type": "repoint", "files": ["imap_1000_001_03.repoint.csv"]},
     ]
@@ -526,8 +528,8 @@ def test_download_all_files():
 
 def test_get_valid_inputs_for_start_date():
     mag_sci_anc = ScienceInput(
-        "imap_mag_l1a_norm-magi_20250101_v000.cdf",
-        "imap_mag_l1a_norm-magi_20250102_v001.cdf",
+        "imap_mag_l1a_norm-magi_20250101_v000.0001.cdf",
+        "imap_mag_l1a_norm-magi_20250102_v001.0001.cdf",
     )
     hit_anc = AncillaryInput(
         "imap_hit_l1b-cal_20250101_v000.cdf",

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -125,7 +125,8 @@ def test_download_daily_data(
             data_level="l0",
             descriptor="raw",
             start_time=day.strftime("%Y%m%d"),
-            version="v000.0001",
+            major_version=0,
+            minor_version=1,
         ).construct_path()
         # There are two swapi apids, so we download the same byte stream twice
         n_apids = len(INSTRUMENT_APIDS[instrument])
@@ -208,7 +209,8 @@ def test_download_repointing_data(
             descriptor="raw",
             start_time=date,
             repointing=repoint_id,
-            version="v000.0001",
+            major_version=0,
+            minor_version=1,
         ).construct_path()
         # There are two hi apids, so we download the same byte stream twice
         n_apids = len(INSTRUMENT_APIDS[instrument])
@@ -249,7 +251,8 @@ def test_file_versioning(
             data_level="l0",
             descriptor="raw",
             start_time=day.strftime("%Y%m%d"),
-            version="v000.0003",
+            major_version=0,
+            minor_version=3,
         ).construct_path()
         # There are two swapi apids, so we download the same byte stream twice
         n_apids = len(INSTRUMENT_APIDS[instrument])


### PR DESCRIPTION
# Change Summary

## Overview
Remove all handling of deprecated version format vXXX for science files. Originally I had made this backwards compatible but since we will be renaming files during a downtime transition period we are able to directly move to the vMMM.mmm format at once. 
