### PR TITLE
Add back vXXX version format to ScienceFilePath

### DIFF
--- a/imap_data_access/file_validation.py
+++ b/imap_data_access/file_validation.py
@@ -312,10 +312,9 @@ class ScienceFilePath(ImapFilePath):
     FILENAME_CONVENTION = (
         "<mission>_<instrument>_<datalevel>_<descriptor>_"
         "<startdate>(-<repointing>)_<version>.<extension>"
-        " where version is vMMM.mmmm (legacy vXXX is deprecated and no longer "
-        "supported.)"
+        " where version is vMMM.mmmm or vXXX."
     )
-    VALID_VERSION_PATTERN: typing.ClassVar[str] = Version.science_version_pattern
+    VALID_VERSION_PATTERN: typing.ClassVar[str] = Version.valid_imap_version_pattern
     VALID_EXTENSIONS: typing.ClassVar[set[str]] = {"cdf", "pkts"}
     _dir_prefix = "imap"
 
@@ -346,8 +345,8 @@ class ScienceFilePath(ImapFilePath):
             repointing the data is from, format: repointXXXXX
         <cr>: This is an optional field describing the Carrington rotation.
             format: crXXXXX.
-        <version>: This stores the data version for this product, format: vMMM.mmmm.
-            vXXX format is deprecated and will raise an error.
+        <version>: This stores the data version for this product, format: vMMM.mmmm or
+        vXXX.
 
         Parameters
         ----------
@@ -397,7 +396,7 @@ class ScienceFilePath(ImapFilePath):
         This can be used instead of the __init__ method to make a new instance:
         ```
         science_file_path = ScienceFilePath.generate_from_inputs("mag", "l0", "test",
-            "20240213", "v001")
+            "20240213", 1, 1)
         full_path = science_file_path.construct_path()
         ```
 
@@ -476,7 +475,6 @@ class ScienceFilePath(ImapFilePath):
                 self.descriptor,
                 self.start_date,
                 self.extension,
-                self.major_version,
                 self.minor_version,
             ]
         ):

--- a/imap_data_access/webpoda.py
+++ b/imap_data_access/webpoda.py
@@ -560,7 +560,7 @@ def _get_latest_version_file_path(
         descriptor="raw",
         start_time=start_time.strftime("%Y%m%d"),
         repointing=repointing,
-        major_version=0,
+        major_version=1,  # L0 files always use major version 1
         minor_version=max_minor_version,
     )
     return science_file.construct_path()

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -66,6 +66,14 @@ def test_extract_filename_components():
         ScienceFilePath.extract_filename_components(valid_filepath) == expected_output
     )
 
+    valid_filepath = Path("/test/imap_mag_l1a_burst_20210101_v001.cdf")  # test with
+    # vXXX format
+    expected_output["extension"] = "cdf"
+    expected_output["major_version"] = None
+    assert (
+        ScienceFilePath.extract_filename_components(valid_filepath) == expected_output
+    )
+
 
 def test_construct_sciencefilepathmanager():
     """Tests that the ``ScienceFilePath`` class constructs a valid filename."""
@@ -195,6 +203,13 @@ def test_generate_from_inputs():
         sfm = ScienceFilePath.generate_from_inputs(
             "glows", "l3a", "test", "20210101", 0, 1, cr=23, repointing=1
         )
+
+    sfm = ScienceFilePath.generate_from_inputs("mag", "l0", "raw", "20210101", None, 1)
+    expected_output = imap_data_access.config["DATA_DIR"] / Path(
+        "imap/mag/l0/2021/01/imap_mag_l0_raw_20210101_v001.pkts"
+    )
+
+    assert sfm.construct_path() == expected_output
 
 
 def test_spice_file_path():

--- a/tests/test_webpoda.py
+++ b/tests/test_webpoda.py
@@ -125,7 +125,7 @@ def test_download_daily_data(
             data_level="l0",
             descriptor="raw",
             start_time=day.strftime("%Y%m%d"),
-            major_version=0,
+            major_version=1,
             minor_version=1,
         ).construct_path()
         # There are two swapi apids, so we download the same byte stream twice
@@ -209,7 +209,7 @@ def test_download_repointing_data(
             descriptor="raw",
             start_time=date,
             repointing=repoint_id,
-            major_version=0,
+            major_version=1,
             minor_version=1,
         ).construct_path()
         # There are two hi apids, so we download the same byte stream twice
@@ -251,7 +251,7 @@ def test_file_versioning(
             data_level="l0",
             descriptor="raw",
             start_time=day.strftime("%Y%m%d"),
-            major_version=0,
+            major_version=1,
             minor_version=3,
         ).construct_path()
         # There are two swapi apids, so we download the same byte stream twice


### PR DESCRIPTION
# Change Summary

## Overview
ScienceFilePath should handle vXXX and vMMM.mmmm version formats. 

## File changes
- imap_data_access/file_validation.py
  - Update ScienceFilePath valid version pattern. 


## Testing
Add tests for vXXX handling. 